### PR TITLE
feat: Add server-side pagination to data tables

### DIFF
--- a/app/blocks/__global/pagination.module.css
+++ b/app/blocks/__global/pagination.module.css
@@ -1,0 +1,77 @@
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  padding: var(--space-4);
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border);
+  border-top: none;
+  border-bottom-left-radius: var(--radius-md);
+  border-bottom-right-radius: var(--radius-md);
+}
+
+.pageSize {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.label {
+  font-size: 13px;
+  color: var(--color-text-muted);
+}
+
+.select {
+  padding: 6px 10px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+}
+
+.select:focus {
+  border-color: var(--color-primary);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-weight: 600;
+  border: 1px solid var(--color-border-strong);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.btn:hover:not(:disabled) {
+  color: var(--color-text);
+  border-color: var(--color-text-muted);
+  background: var(--color-bg-hover);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.indicator {
+  font-size: 13px;
+  color: var(--color-text-muted);
+  font-weight: 500;
+}

--- a/app/blocks/__global/pagination.tsx
+++ b/app/blocks/__global/pagination.tsx
@@ -1,0 +1,70 @@
+import { useSearchParams } from "react-router";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+import styles from "./pagination.module.css";
+
+interface Props {
+  totalPages: number;
+}
+
+export function Pagination({ totalPages }: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentPage = Math.max(1, Number(searchParams.get("page")) || 1);
+  const pageSize = Number(searchParams.get("pageSize")) || 10;
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage < 1 || newPage > totalPages) return;
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("page", String(newPage));
+    setSearchParams(nextParams);
+  };
+
+  const handlePageSizeChange = (newSize: number) => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("pageSize", String(newSize));
+    nextParams.set("page", "1"); // Reset to page 1
+    setSearchParams(nextParams);
+  };
+
+  if (totalPages <= 1 && pageSize === 10) return null;
+
+  return (
+    <div className={styles.pagination}>
+      <div className={styles.pageSize}>
+        <span className={styles.label}>Rows per page:</span>
+        <select
+          className={styles.select}
+          value={pageSize}
+          onChange={(e) => handlePageSizeChange(Number(e.target.value))}
+        >
+          <option value={10}>10</option>
+          <option value={25}>25</option>
+          <option value={50}>50</option>
+        </select>
+      </div>
+
+      <div className={styles.nav}>
+        <button
+          className={styles.btn}
+          disabled={currentPage <= 1}
+          onClick={() => handlePageChange(currentPage - 1)}
+          aria-label="Previous Page"
+        >
+          <IconChevronLeft size={16} />
+          <span>Previous</span>
+        </button>
+        <span className={styles.indicator}>
+          Page {currentPage} of {totalPages || 1}
+        </span>
+        <button
+          className={styles.btn}
+          disabled={currentPage >= totalPages}
+          onClick={() => handlePageChange(currentPage + 1)}
+          aria-label="Next Page"
+        >
+          <span>Next</span>
+          <IconChevronRight size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/blocks/expenses-tracker/expenses-summary.tsx
+++ b/app/blocks/expenses-tracker/expenses-summary.tsx
@@ -1,11 +1,18 @@
 import styles from "./expenses-summary.module.css";
 
-interface Props { className?: string; expenses?: any[]; recurring?: any[]; }
+interface Props { 
+  className?: string; 
+  expenses?: any[]; 
+  recurring?: any[]; 
+  oneTimeTotal?: number;
+}
 
-export function ExpensesSummary({ className, expenses = [], recurring = [] }: Props) {
-  let totalExpenses = 0;
-  
-  expenses.forEach(e => totalExpenses += Number(e.amount));
+export function ExpensesSummary({ className, expenses = [], recurring = [], oneTimeTotal }: Props) {
+  const oneTimeSum = typeof oneTimeTotal === "number"
+    ? oneTimeTotal
+    : expenses.reduce((acc, e) => acc + Number(e.amount), 0);
+
+  let totalExpenses = oneTimeSum;
   recurring.forEach(r => {
     if (r.isActive) totalExpenses += Number(r.amount);
   });
@@ -13,7 +20,7 @@ export function ExpensesSummary({ className, expenses = [], recurring = [] }: Pr
   const cards = [
     { label: "Total Expenses", value: `$${totalExpenses.toFixed(2)}`, sub: "All time" },
     { label: "Recurring Monthly", value: `$${recurring.filter(r => r.isActive).reduce((acc, r) => acc + Number(r.amount), 0).toFixed(2)}`, sub: "Active subscriptions" },
-    { label: "One-Time Expenses", value: `$${expenses.reduce((acc, e) => acc + Number(e.amount), 0).toFixed(2)}`, sub: "Logged purchases" },
+    { label: "One-Time Expenses", value: `$${oneTimeSum.toFixed(2)}`, sub: "Logged purchases" },
   ];
 
   return (

--- a/app/blocks/sales-log/sales-summary-cards.tsx
+++ b/app/blocks/sales-log/sales-summary-cards.tsx
@@ -1,19 +1,22 @@
 import styles from "./sales-summary-cards.module.css";
 
-interface Props { className?: string; sales?: any[]; }
+interface Props { 
+  className?: string; 
+  sales?: any[]; 
+  summary?: {
+    totalSalesCount: number;
+    totalRevenue: number;
+    totalProfit: number;
+  };
+}
 
-export function SalesSummaryCards({ className, sales = [] }: Props) {
-  const totalSales = sales.length;
+export function SalesSummaryCards({ className, sales = [], summary }: Props) {
+  const totalSales = summary ? summary.totalSalesCount : sales.length;
   
-  let totalRevenue = 0;
-  let totalProfit = 0;
-  
-  sales.forEach(s => {
-    const salePrice = Number(s.salePrice);
-    const cost = Number(s.inventoryItem.purchasePrice);
-    totalRevenue += salePrice;
-    totalProfit += (salePrice - cost);
-  });
+  const totalRevenue = summary ? summary.totalRevenue : sales.reduce((acc, s) => acc + Number(s.salePrice), 0);
+  const totalProfit = summary 
+    ? summary.totalProfit 
+    : sales.reduce((acc, s) => acc + (Number(s.salePrice) - Number(s.inventoryItem.purchasePrice)), 0);
   
   const avgProfit = totalSales > 0 ? (totalProfit / totalSales) : 0;
 

--- a/app/routes/expenses-tracker.tsx
+++ b/app/routes/expenses-tracker.tsx
@@ -10,6 +10,7 @@ import { RecurringExpensesSection } from "~/blocks/expenses-tracker/recurring-ex
 import { OneTimeExpensesTable } from "~/blocks/expenses-tracker/one-time-expenses-table";
 import { ExpensesSummary } from "~/blocks/expenses-tracker/expenses-summary";
 import { AddExpenseModal } from "~/blocks/expenses-tracker/add-expense-modal";
+import { Pagination } from "~/blocks/__global/pagination";
 
 const prisma = new PrismaClient();
 
@@ -17,20 +18,36 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);
   const { data: { user } } = await supabase.auth.getUser();
 
-  if (!user) return { expenses: [], recurring: [] };
+  if (!user) return { expenses: [], recurring: [], totalPages: 0, oneTimeTotal: 0 };
 
-  const [expenses, recurring] = await Promise.all([
+  const url = new URL(request.url);
+  const page = Math.max(1, Number(url.searchParams.get("page")) || 1);
+  const pageSize = Number(url.searchParams.get("pageSize")) || 10;
+
+  const [totalExpenses, expenses, recurring, sumResult] = await Promise.all([
+    prisma.expense.count({ where: { userId: user.id } }),
     prisma.expense.findMany({
       where: { userId: user.id },
       orderBy: { date: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
     }),
     prisma.recurringExpense.findMany({
       where: { userId: user.id },
       orderBy: { createdAt: "desc" },
     }),
+    prisma.expense.aggregate({
+      where: { userId: user.id },
+      _sum: { amount: true }
+    })
   ]);
 
-  return { expenses, recurring };
+  return {
+    expenses,
+    recurring,
+    totalPages: Math.ceil(totalExpenses / pageSize),
+    oneTimeTotal: Number(sumResult._sum.amount || 0)
+  };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -77,7 +94,7 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function ExpensesTrackerPage() {
-  const { expenses, recurring } = useLoaderData<typeof loader>();
+  const { expenses, recurring, totalPages, oneTimeTotal } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const [showAddExpense, setShowAddExpense] = useState(false);
 
@@ -93,9 +110,10 @@ export default function ExpensesTrackerPage() {
   return (
     <div className={styles.page}>
       <ExpensesHeader onAddExpense={() => setShowAddExpense(true)} />
-      <ExpensesSummary expenses={expenses} recurring={recurring} />
+      <ExpensesSummary expenses={expenses} recurring={recurring} oneTimeTotal={oneTimeTotal} />
       <RecurringExpensesSection recurring={recurring} />
       <OneTimeExpensesTable expenses={expenses} />
+      <Pagination totalPages={totalPages} />
       {showAddExpense && <AddExpenseModal onClose={() => setShowAddExpense(false)} />}
     </div>
   );

--- a/app/routes/inventory-management.tsx
+++ b/app/routes/inventory-management.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useLoaderData, useActionData } from "react-router";
+import { useLoaderData, useActionData, useSearchParams } from "react-router";
 import type { Route } from "./+types/inventory-management";
 import { toast } from "sonner";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
@@ -10,6 +10,7 @@ import { InventoryTable } from "~/blocks/inventory-management/inventory-table";
 import { BulkActionsBar } from "~/blocks/inventory-management/bulk-actions-bar";
 import { AddItemModal } from "~/blocks/inventory-management/add-item-modal";
 import { ImportExcelModal } from "~/blocks/inventory-management/import-excel-modal";
+import { Pagination } from "~/blocks/__global/pagination";
 
 const prisma = new PrismaClient();
 
@@ -17,25 +18,48 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);
   const { data: { user } } = await supabase.auth.getUser();
 
-  if (!user) return { items: [] };
+  if (!user) return { items: [], totalPages: 0 };
 
-  const items = await prisma.inventoryItem.findMany({
-    where: { userId: user.id },
-    orderBy: { createdAt: "desc" },
-    include: {
-      priceHistory: {
-        orderBy: { fetchedAt: "desc" },
-        take: 1
-      }
-    }
-  });
+  const url = new URL(request.url);
+  const page = Math.max(1, Number(url.searchParams.get("page")) || 1);
+  const pageSize = Number(url.searchParams.get("pageSize")) || 10;
+  const q = url.searchParams.get("q") || "";
 
-  const formattedItems = items.map(item => ({
+  const whereClause = {
+    userId: user.id,
+    ...(q
+      ? {
+          OR: [
+            { name: { contains: q, mode: "insensitive" as const } },
+            { sku: { contains: q, mode: "insensitive" as const } },
+            { brand: { contains: q, mode: "insensitive" as const } },
+          ],
+        }
+      : {}),
+  };
+
+  const [totalItems, items] = await Promise.all([
+    prisma.inventoryItem.count({ where: whereClause }),
+    prisma.inventoryItem.findMany({
+      where: whereClause,
+      orderBy: { createdAt: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
+      include: {
+        priceHistory: {
+          orderBy: { fetchedAt: "desc" },
+          take: 1,
+        },
+      },
+    }),
+  ]);
+
+  const formattedItems = items.map((item) => ({
     ...item,
     marketValue: item.priceHistory[0]?.askPrice ? Number(item.priceHistory[0].askPrice) : null,
   }));
 
-  return { items: formattedItems };
+  return { items: formattedItems, totalPages: Math.ceil(totalItems / pageSize) };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -107,13 +131,26 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function InventoryManagementPage() {
-  const { items } = useLoaderData<typeof loader>();
+  const { items, totalPages } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const [showAddItem, setShowAddItem] = useState(false);
   const [showImport, setShowImport] = useState(false);
   const [selected, setSelected] = useState<string[]>([]);
   const [editingItem, setEditingItem] = useState<any>(null);
-  const [searchQuery, setSearchQuery] = useState("");
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const searchQuery = searchParams.get("q") || "";
+
+  const setSearchQuery = (query: string) => {
+    const nextParams = new URLSearchParams(searchParams);
+    if (query) {
+      nextParams.set("q", query);
+    } else {
+      nextParams.delete("q");
+    }
+    nextParams.set("page", "1"); // Reset to page 1
+    setSearchParams(nextParams, { replace: true });
+  };
 
   useEffect(() => {
     if (actionData?.ok) {
@@ -135,16 +172,6 @@ export default function InventoryManagementPage() {
     }
   }, [actionData]);
 
-  const filteredItems = items.filter((item) => {
-    if (!searchQuery) return true;
-    const lowerQuery = searchQuery.toLowerCase();
-    return (
-      (item.name?.toLowerCase() || "").includes(lowerQuery) ||
-      (item.sku?.toLowerCase() || "").includes(lowerQuery) ||
-      (item.brand?.toLowerCase() || "").includes(lowerQuery)
-    );
-  });
-
   return (
     <div className={styles.page}>
       <InventoryHeader
@@ -156,7 +183,8 @@ export default function InventoryManagementPage() {
       {selected.length > 0 && (
         <BulkActionsBar count={selected.length} onClear={() => setSelected([])} selectedIds={selected} items={items} />
       )}
-      <InventoryTable selected={selected} onSelectChange={setSelected} items={filteredItems} onEdit={setEditingItem} />
+      <InventoryTable selected={selected} onSelectChange={setSelected} items={items} onEdit={setEditingItem} />
+      <Pagination totalPages={totalPages} />
       {showAddItem && <AddItemModal onClose={() => setShowAddItem(false)} />}
       {editingItem && <AddItemModal item={editingItem} onClose={() => setEditingItem(null)} />}
       {showImport && <ImportExcelModal onClose={() => setShowImport(false)} />}

--- a/app/routes/sales-log.tsx
+++ b/app/routes/sales-log.tsx
@@ -9,6 +9,7 @@ import { SalesHeader } from "~/blocks/sales-log/sales-header";
 import { SalesSummaryCards } from "~/blocks/sales-log/sales-summary-cards";
 import { SalesTable } from "~/blocks/sales-log/sales-table";
 import { LogSaleModal } from "~/blocks/sales-log/log-sale-modal";
+import { Pagination } from "~/blocks/__global/pagination";
 
 const prisma = new PrismaClient();
 
@@ -16,21 +17,55 @@ export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);
   const { data: { user } } = await supabase.auth.getUser();
 
-  if (!user) return { sales: [], inventory: [] };
+  if (!user) return { sales: [], inventory: [], totalPages: 0, summary: { totalSalesCount: 0, totalRevenue: 0, totalProfit: 0 } };
 
-  const [sales, inventory] = await Promise.all([
+  const url = new URL(request.url);
+  const page = Math.max(1, Number(url.searchParams.get("page")) || 1);
+  const pageSize = Number(url.searchParams.get("pageSize")) || 10;
+
+  const [totalSales, sales, inventory, allSalesMetrics] = await Promise.all([
+    prisma.sale.count({ where: { userId: user.id } }),
     prisma.sale.findMany({
       where: { userId: user.id },
       include: { inventoryItem: true },
       orderBy: { saleDate: "desc" },
+      skip: (page - 1) * pageSize,
+      take: pageSize,
     }),
     prisma.inventoryItem.findMany({
       where: { userId: user.id, status: "IN_STOCK" },
       orderBy: { createdAt: "desc" },
     }),
+    prisma.sale.findMany({
+      where: { userId: user.id },
+      select: {
+        salePrice: true,
+        inventoryItem: {
+          select: { purchasePrice: true }
+        }
+      }
+    })
   ]);
 
-  return { sales, inventory };
+  let totalRevenue = 0;
+  let totalProfit = 0;
+  allSalesMetrics.forEach(s => {
+    const salePrice = Number(s.salePrice);
+    const cost = Number(s.inventoryItem.purchasePrice);
+    totalRevenue += salePrice;
+    totalProfit += (salePrice - cost);
+  });
+
+  return {
+    sales,
+    inventory,
+    totalPages: Math.ceil(totalSales / pageSize),
+    summary: {
+      totalSalesCount: totalSales,
+      totalRevenue,
+      totalProfit
+    }
+  };
 }
 
 export async function action({ request }: Route.ActionArgs) {
@@ -70,7 +105,7 @@ export async function action({ request }: Route.ActionArgs) {
 }
 
 export default function SalesLogPage() {
-  const { sales, inventory } = useLoaderData<typeof loader>();
+  const { sales, inventory, totalPages, summary } = useLoaderData<typeof loader>();
   const actionData = useActionData<typeof action>();
   const [showLogSale, setShowLogSale] = useState(false);
 
@@ -86,8 +121,9 @@ export default function SalesLogPage() {
   return (
     <div className={styles.page}>
       <SalesHeader onLogSale={() => setShowLogSale(true)} />
-      <SalesSummaryCards sales={sales} />
+      <SalesSummaryCards sales={sales} summary={summary} />
       <SalesTable sales={sales} />
+      <Pagination totalPages={totalPages} />
       {showLogSale && <LogSaleModal inventory={inventory} onClose={() => setShowLogSale(false)} />}
     </div>
   );


### PR DESCRIPTION
## Description
This PR introduces server-side pagination to the Inventory, Sales Log, and One-Time Expenses tables in FlipTrack. 
It loads data in chunks of 10, 25, or 50 records using Prisma offset limits, lowering client-side memory usage and network transfer sizes.

Key changes:
- Created a reusable `<Pagination />` component in `app/blocks/__global/` that syncs page and page size directly to the URL search parameters.
- Replaced the client-side search filter on the Inventory page with a server-side search parameterized query (`q`), allowing correct pagination over filtered sets.
- Computed overall total stats on the server for Sales Log and Expenses so that metric overview cards continue to display accurate totals across different pages.

## Related Issues
Fixes #2

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
