### PR TITLE
feat: Build Tax Report Loader & Connect Real Data

### DIFF
--- a/app/blocks/tax-report-export/report-preview.tsx
+++ b/app/blocks/tax-report-export/report-preview.tsx
@@ -1,11 +1,32 @@
-import { mockSales } from "~/data/mock-data";
 import styles from "./report-preview.module.css";
 
-interface Props { className?: string; }
+interface SaleItem {
+  id: string;
+  item: string;
+  salePrice: number;
+  marketplace: string;
+  date: string;
+  profit: number;
+  margin: number;
+}
 
-export function ReportPreview({ className }: Props) {
-  const totalProceeds = mockSales.reduce((s, sale) => s + sale.salePrice, 0);
-  const totalGains = mockSales.reduce((s, sale) => s + sale.profit, 0);
+interface ExpenseItem {
+  id: string;
+  amount: number;
+  description: string | null;
+  type: string;
+  date: string;
+}
+
+interface Props {
+  className?: string;
+  sales: SaleItem[];
+  expenses: ExpenseItem[];
+}
+
+export function ReportPreview({ className, sales }: Props) {
+  const totalProceeds = sales.reduce((s, sale) => s + sale.salePrice, 0);
+  const totalGains = sales.reduce((s, sale) => s + sale.profit, 0);
 
   return (
     <div className={[styles.card, className].filter(Boolean).join(" ")}>
@@ -29,7 +50,7 @@ export function ReportPreview({ className }: Props) {
             </tr>
           </thead>
           <tbody>
-            {mockSales.map(s => (
+            {sales.map(s => (
               <tr key={s.id} className={styles.tr}>
                 <td className={styles.td}>{s.date}</td>
                 <td className={styles.td}>{s.item}</td>

--- a/app/routes/tax-report-export.tsx
+++ b/app/routes/tax-report-export.tsx
@@ -1,3 +1,7 @@
+import { useLoaderData } from "react-router";
+import type { Route } from "./+types/tax-report-export";
+import { getSupabaseServerClient } from "~/utils/supabase.server";
+import { PrismaClient } from "@prisma/client";
 import styles from "./tax-report-export.module.css";
 import { TaxReportHeader } from "~/blocks/tax-report-export/tax-report-header";
 import { ReportGenerator } from "~/blocks/tax-report-export/report-generator";
@@ -5,12 +9,57 @@ import { ReportPreview } from "~/blocks/tax-report-export/report-preview";
 import { ExportOptions } from "~/blocks/tax-report-export/export-options";
 import { ReportHistory } from "~/blocks/tax-report-export/report-history";
 
+const prisma = new PrismaClient();
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const { supabase } = getSupabaseServerClient(request);
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) return { sales: [], expenses: [] };
+
+  const [sales, expenses] = await Promise.all([
+    prisma.sale.findMany({
+      where: { userId: user.id },
+      include: { inventoryItem: true },
+      orderBy: { saleDate: "desc" },
+    }),
+    prisma.expense.findMany({
+      where: { userId: user.id },
+      orderBy: { date: "desc" },
+    }),
+  ]);
+
+  const serializedSales = sales.map(s => {
+    const salePrice = Number(s.salePrice);
+    const purchasePrice = Number(s.inventoryItem.purchasePrice);
+    const profit = salePrice - purchasePrice;
+    return {
+      id: s.id,
+      item: s.inventoryItem.name,
+      salePrice,
+      marketplace: s.marketplace,
+      date: s.saleDate.toISOString().slice(0, 10),
+      profit,
+      margin: salePrice > 0 ? Math.round((profit / salePrice) * 100) : 0,
+    };
+  });
+
+  const serializedExpenses = expenses.map(e => ({
+    ...e,
+    amount: Number(e.amount),
+  }));
+
+  return { sales: serializedSales, expenses: serializedExpenses };
+}
+
 export default function TaxReportExportPage() {
+  const { sales, expenses } = useLoaderData<typeof loader>();
+
   return (
     <div className={styles.page}>
       <TaxReportHeader />
       <ReportGenerator />
-      <ReportPreview />
+      <ReportPreview sales={sales} expenses={expenses} />
       <ExportOptions />
       <ReportHistory />
     </div>


### PR DESCRIPTION
# Pull Request

## Description

The **Tax Report** page (`/app/tax-report`) previously relied entirely on static mock data (`mockSales`) and had no server-side data loading. This PR replaces the mock implementation with a real Remix loader that fetches tax report data directly from the database using Prisma.

---

## Changes

### `app/routes/tax-report-export.tsx`
- Added a Remix `loader` function to provide real tax report data.
- Authenticates the current user using Supabase SSR.
- Fetches the authenticated user's:
  - Sales records (including related inventory item data for item name and cost basis).
  - Expense records from Prisma.
- Serializes Prisma `Decimal` values into JavaScript `Number` for client-side compatibility.
- Computes profit and profit margin for each sale before returning the response.

### `app/blocks/tax-report-export/report-preview.tsx`
- Refactored the `ReportPreview` component to receive `sales` and `expenses` as props.
- Removed the dependency on static `mockSales` data.
- Updated the component to render live database-backed report data.

---

## Related Issues

closes #22 

---

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update

---

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.