### PR TITLE
feat: Add Date Range Filtering to Dashboard

### DIFF
--- a/app/blocks/dashboard/dashboard-header.module.css
+++ b/app/blocks/dashboard/dashboard-header.module.css
@@ -5,3 +5,8 @@
 .select:focus { border-color: var(--color-primary); }
 .exportBtn { display: flex; align-items: center; gap: var(--space-2); padding: 8px 14px; border-radius: var(--radius-sm); background: var(--color-bg-elevated); border: 1px solid var(--color-border); color: var(--color-text-muted); font-size: 13px; cursor: pointer; transition: all var(--transition-fast); }
 .exportBtn:hover { color: var(--color-text); border-color: var(--color-border-strong); }
+
+.customDates { display: flex; align-items: center; gap: var(--space-2); }
+.dateInput { padding: 8px 12px; border-radius: var(--radius-sm); background: var(--color-bg-elevated); border: 1px solid var(--color-border); color: var(--color-text); font-size: 13px; outline: none; }
+.dateInput:focus { border-color: var(--color-primary); }
+.dateSeparator { color: var(--color-text-muted); font-size: 13px; }

--- a/app/blocks/dashboard/dashboard-header.tsx
+++ b/app/blocks/dashboard/dashboard-header.tsx
@@ -1,14 +1,60 @@
+import { useSearchParams } from "react-router";
 import { IconDownload } from "@tabler/icons-react";
 import styles from "./dashboard-header.module.css";
 
 interface Props { className?: string; }
 
 export function DashboardHeader({ className }: Props) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const range = searchParams.get("range") || "month";
+  const from = searchParams.get("from") || "";
+  const to = searchParams.get("to") || "";
+
+  const handleRangeChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const value = e.target.value;
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("range", value);
+    if (value !== "custom") {
+      nextParams.delete("from");
+      nextParams.delete("to");
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
+
+  const handleDateChange = (key: "from" | "to", value: string) => {
+    const nextParams = new URLSearchParams(searchParams);
+    if (value) {
+      nextParams.set(key, value);
+    } else {
+      nextParams.delete(key);
+    }
+    setSearchParams(nextParams, { replace: true });
+  };
+
   return (
     <div className={[styles.header, className].filter(Boolean).join(" ")}>
       <h1 className={styles.title}>Dashboard</h1>
       <div className={styles.controls}>
-        <select className={styles.select} defaultValue="month">
+        {range === "custom" && (
+          <div className={styles.customDates}>
+            <input
+              type="date"
+              className={styles.dateInput}
+              value={from}
+              onChange={(e) => handleDateChange("from", e.target.value)}
+              placeholder="From"
+            />
+            <span className={styles.dateSeparator}>to</span>
+            <input
+              type="date"
+              className={styles.dateInput}
+              value={to}
+              onChange={(e) => handleDateChange("to", e.target.value)}
+              placeholder="To"
+            />
+          </div>
+        )}
+        <select className={styles.select} value={range} onChange={handleRangeChange}>
           <option value="month">This Month</option>
           <option value="3months">Last 3 Months</option>
           <option value="year">Last Year</option>

--- a/app/blocks/dashboard/dashboard-header.tsx
+++ b/app/blocks/dashboard/dashboard-header.tsx
@@ -24,7 +24,10 @@ export function DashboardHeader({ className }: Props) {
   const handleDateChange = (key: "from" | "to", value: string) => {
     const nextParams = new URLSearchParams(searchParams);
     if (value) {
-      nextParams.set(key, value);
+      const parsedDate = new Date(value);
+      if (!isNaN(parsedDate.getTime())) {
+        nextParams.set(key, value);
+      }
     } else {
       nextParams.delete(key);
     }
@@ -36,31 +39,38 @@ export function DashboardHeader({ className }: Props) {
       <h1 className={styles.title}>Dashboard</h1>
       <div className={styles.controls}>
         {range === "custom" && (
-          <div className={styles.customDates}>
+          <div className={styles.customDates} role="group" aria-label="Custom Date Range Selector">
             <input
               type="date"
               className={styles.dateInput}
               value={from}
               onChange={(e) => handleDateChange("from", e.target.value)}
               placeholder="From"
+              aria-label="Start date"
             />
-            <span className={styles.dateSeparator}>to</span>
+            <span className={styles.dateSeparator} aria-hidden="true">to</span>
             <input
               type="date"
               className={styles.dateInput}
               value={to}
               onChange={(e) => handleDateChange("to", e.target.value)}
               placeholder="To"
+              aria-label="End date"
             />
           </div>
         )}
-        <select className={styles.select} value={range} onChange={handleRangeChange}>
+        <select
+          className={styles.select}
+          value={range}
+          onChange={handleRangeChange}
+          aria-label="Filter dashboard by date range"
+        >
           <option value="month">This Month</option>
           <option value="3months">Last 3 Months</option>
           <option value="year">Last Year</option>
           <option value="custom">Custom</option>
         </select>
-        <button className={styles.exportBtn}>
+        <button className={styles.exportBtn} aria-label="Export dashboard data">
           <IconDownload size={14} /> Export
         </button>
       </div>

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -24,6 +24,55 @@ export async function loader({ request }: Route.LoaderArgs) {
     return { inventoryStats: null, salesData: [], expensesData: [] };
   }
 
+  const url = new URL(request.url);
+  const range = url.searchParams.get("range") || "month";
+  const from = url.searchParams.get("from");
+  const to = url.searchParams.get("to");
+
+  let startDate: Date | undefined;
+  let endDate: Date | undefined;
+  const now = new Date();
+
+  if (range === "month") {
+    startDate = new Date(now.getFullYear(), now.getMonth(), 1);
+  } else if (range === "3months") {
+    startDate = new Date();
+    startDate.setDate(now.getDate() - 90);
+  } else if (range === "year") {
+    startDate = new Date();
+    startDate.setDate(now.getDate() - 365);
+  } else if (range === "custom") {
+    if (from) {
+      const parsedFrom = new Date(from);
+      if (!isNaN(parsedFrom.getTime())) {
+        startDate = parsedFrom;
+      }
+    }
+    if (to) {
+      const parsedTo = new Date(to);
+      if (!isNaN(parsedTo.getTime())) {
+        endDate = parsedTo;
+        endDate.setHours(23, 59, 59, 999);
+      }
+    }
+  }
+
+  const saleWhereClause: any = { userId: user.id };
+  const expenseWhereClause: any = { userId: user.id };
+
+  if (startDate || endDate) {
+    saleWhereClause.saleDate = {};
+    expenseWhereClause.date = {};
+    if (startDate) {
+      saleWhereClause.saleDate.gte = startDate;
+      expenseWhereClause.date.gte = startDate;
+    }
+    if (endDate) {
+      saleWhereClause.saleDate.lte = endDate;
+      expenseWhereClause.date.lte = endDate;
+    }
+  }
+
   const [inventoryStats, salesData, expensesData] = await Promise.all([
     prisma.inventoryItem.aggregate({
       where: { userId: user.id, status: 'IN_STOCK' },
@@ -31,12 +80,12 @@ export async function loader({ request }: Route.LoaderArgs) {
       _count: true,
     }),
     prisma.sale.findMany({
-      where: { userId: user.id },
+      where: saleWhereClause,
       include: { expenses: true, inventoryItem: true },
       orderBy: { saleDate: 'desc' },
     }),
     prisma.expense.findMany({
-      where: { userId: user.id },
+      where: expenseWhereClause,
     }),
   ]);
 

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -1,7 +1,7 @@
 import { useLoaderData } from "react-router";
 import type { Route } from "./+types/dashboard";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, Prisma } from "@prisma/client";
 import styles from "./dashboard.module.css";
 import { DashboardHeader } from "~/blocks/dashboard/dashboard-header";
 import { StatsCardsRow } from "~/blocks/dashboard/stats-cards-row";
@@ -57,21 +57,29 @@ export async function loader({ request }: Route.LoaderArgs) {
     }
   }
 
-  const saleWhereClause: any = { userId: user.id };
-  const expenseWhereClause: any = { userId: user.id };
+  const saleWhereClause: Prisma.SaleWhereInput = {
+    userId: user.id,
+    ...(startDate || endDate
+      ? {
+          saleDate: {
+            ...(startDate ? { gte: startDate } : {}),
+            ...(endDate ? { lte: endDate } : {}),
+          },
+        }
+      : {}),
+  };
 
-  if (startDate || endDate) {
-    saleWhereClause.saleDate = {};
-    expenseWhereClause.date = {};
-    if (startDate) {
-      saleWhereClause.saleDate.gte = startDate;
-      expenseWhereClause.date.gte = startDate;
-    }
-    if (endDate) {
-      saleWhereClause.saleDate.lte = endDate;
-      expenseWhereClause.date.lte = endDate;
-    }
-  }
+  const expenseWhereClause: Prisma.ExpenseWhereInput = {
+    userId: user.id,
+    ...(startDate || endDate
+      ? {
+          date: {
+            ...(startDate ? { gte: startDate } : {}),
+            ...(endDate ? { lte: endDate } : {}),
+          },
+        }
+      : {}),
+  };
 
   const [inventoryStats, salesData, expensesData] = await Promise.all([
     prisma.inventoryItem.aggregate({


### PR DESCRIPTION
## Description
This PR implements dynamic date range filtering on the Dashboard using URL search parameters, allowing users to filter sales and expenses data. 

Key changes:
- Configured the select dropdown in the dashboard header to update the URL `range` parameter (`month`, `3months`, `year`, `custom`).
- Rendered inline start (`from`) and end (`to`) date selectors dynamically when `custom` range is selected.
- Updated the dashboard server loader to parse the query parameters, calculate date offsets, validate input strings, and apply date-range filtering to Prisma queries on the `Sale` and `Expense` models.

## Related Issues
Fixes #5

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
