### PR TITLE
feat(inventory): implement dynamic inventory item detail page

### DIFF
--- a/app/blocks/inventory-item-detail/item-header.tsx
+++ b/app/blocks/inventory-item-detail/item-header.tsx
@@ -1,20 +1,38 @@
+import type { InventoryItem } from "@prisma/client";
 import styles from "./item-header.module.css";
 
-interface Props { className?: string; }
+interface Props {
+  className?: string;
+  item: Pick<InventoryItem, "sku" | "name" | "brand" | "size" | "condition" | "imageUrl">;
+}
 
-export function ItemHeader({ className }: Props) {
+export function ItemHeader({ className, item }: Props) {
+  const displayCondition = item.condition
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (l) => l.toUpperCase());
   return (
     <div className={[styles.header, className].filter(Boolean).join(" ")}>
-      <div className={styles.image}>Product Image</div>
+      <div className={styles.image}>
+        {item.imageUrl ? (
+          <img
+            src={item.imageUrl}
+            alt={item.name}
+            style={{ width: "100%", height: "100%", objectFit: "cover", borderRadius: "inherit" }}
+          />
+        ) : (
+          "Product Image"
+        )}
+      </div>
       <div className={styles.info}>
-        <div className={styles.sku}>DD1391-100</div>
-        <h1 className={styles.name}>Air Jordan 1 Retro High OG Chicago</h1>
+        <div className={styles.sku}>{item.sku}</div>
+        <h1 className={styles.name}>{item.name}</h1>
         <div className={styles.meta}>
-          <span>Nike</span>
+          <span>{item.brand}</span>
           <span>·</span>
-          <span>Size 10</span>
+          <span>Size {item.size}</span>
           <span>·</span>
-          <span>Deadstock</span>
+          <span>{displayCondition}</span>
         </div>
       </div>
       <div className={styles.actions}>

--- a/app/blocks/inventory-item-detail/item-info-card.tsx
+++ b/app/blocks/inventory-item-detail/item-info-card.tsx
@@ -1,17 +1,67 @@
+import type { InventoryItem } from "@prisma/client";
 import styles from "./item-info-card.module.css";
 
-interface Props { className?: string; }
+interface Props {
+  className?: string;
+  item: Pick<InventoryItem, "condition" | "status" | "notes" | "currency"> & {
+    purchasePrice: number;
+    purchaseDate: string | Date;
+    askingPrice: number | null;
+  };
+}
 
-export function ItemInfoCard({ className }: Props) {
+export function ItemInfoCard({ className, item }: Props) {
+  const displayCondition = item.condition
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (l) => l.toUpperCase());
+
+  const displayStatus = item.status
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (l) => l.toUpperCase());
+
+  const formattedPurchaseDate = new Date(item.purchaseDate).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  const formatMoney = (val: number | null, currency: string = "USD") => {
+    if (val == null) return "N/A";
+    return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(val);
+  };
   return (
     <div className={[styles.card, className].filter(Boolean).join(" ")}>
       <div className={styles.title}>Item Details</div>
-      <div className={styles.field}><div className={styles.label}>Purchase Price</div><div className={[styles.value, styles.money].join(" ")}>$170.00</div></div>
-      <div className={styles.field}><div className={styles.label}>Purchase Date</div><div className={styles.value}>Jan 18, 2024</div></div>
-      <div className={styles.field}><div className={styles.label}>Condition</div><div className={styles.value}>Deadstock</div></div>
-      <div className={styles.field}><div className={styles.label}>Status</div><div className={styles.value}><span className={styles.badge}>In Stock</span></div></div>
-      <div className={styles.field}><div className={styles.label}>Asking Price</div><div className={[styles.value, styles.money].join(" ")}>$450.00</div></div>
-      <div className={styles.field}><div className={styles.label}>Notes</div><div className={styles.value}>Purchased during Nike SNKRS drop</div></div>
+      <div className={styles.field}>
+        <div className={styles.label}>Purchase Price</div>
+        <div className={[styles.value, styles.money].join(" ")}>{formatMoney(item.purchasePrice, item.currency)}</div>
+      </div>
+      <div className={styles.field}>
+        <div className={styles.label}>Purchase Date</div>
+        <div className={styles.value}>{formattedPurchaseDate}</div>
+      </div>
+      <div className={styles.field}>
+        <div className={styles.label}>Condition</div>
+        <div className={styles.value}>{displayCondition}</div>
+      </div>
+      <div className={styles.field}>
+        <div className={styles.label}>Status</div>
+        <div className={styles.value}>
+          <span className={styles.badge}>{displayStatus}</span>
+        </div>
+      </div>
+      <div className={styles.field}>
+        <div className={styles.label}>Asking Price</div>
+        <div className={[styles.value, styles.money].join(" ")}>{formatMoney(item.askingPrice, item.currency)}</div>
+      </div>
+      <div className={styles.field}>
+        <div className={styles.label}>Notes</div>
+        <div className={styles.value}>
+          {item.notes || <span style={{ color: "var(--color-text-subtle)" }}>None</span>}
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/blocks/inventory-item-detail/marketplace-comparison.tsx
+++ b/app/blocks/inventory-item-detail/marketplace-comparison.tsx
@@ -1,16 +1,80 @@
+import type { MarketPrice } from "@prisma/client";
 import styles from "./marketplace-comparison.module.css";
 
-interface Props { className?: string; }
+interface Props {
+  className?: string;
+  priceHistory: (Pick<MarketPrice, "marketplace"> & {
+    fetchedAt: string | Date;
+    askPrice: number | null;
+    bidPrice: number | null;
+    lastSold: number | null;
+  })[];
+}
 
-const data = [
-  { name: "StockX", ask: 440, lastSold: 435, bid: 415, best: true },
-  { name: "GOAT", ask: 415, lastSold: 410, bid: 400, best: false },
-  { name: "eBay", ask: 380, lastSold: 365, bid: null, best: false },
-  { name: "Flight Club", ask: 445, lastSold: 440, bid: null, best: false },
-  { name: "Stadium Goods", ask: 430, lastSold: 422, bid: null, best: false },
-];
+const formatMarketplaceName = (name: string) => {
+  const map: Record<string, string> = {
+    stockx: "StockX",
+    goat: "GOAT",
+    ebay: "eBay",
+    flightclub: "Flight Club",
+    stadiumgoods: "Stadium Goods",
+  };
+  return map[name.toLowerCase()] || name;
+};
 
-export function MarketplaceComparison({ className }: Props) {
+export function MarketplaceComparison({ className, priceHistory }: Props) {
+  if (!priceHistory || priceHistory.length === 0) {
+    return (
+      <div className={[styles.card, className].filter(Boolean).join(" ")}>
+        <div className={styles.title}>Marketplace Comparison</div>
+        <p
+          style={{
+            fontSize: 14,
+            color: "var(--color-text-muted)",
+            textAlign: "center",
+            padding: "var(--space-6)",
+            margin: 0,
+          }}
+        >
+          No marketplace data available.
+        </p>
+      </div>
+    );
+  }
+
+  // Get the most recent record for each marketplace
+  // Assuming priceHistory is already sorted by fetchedAt desc
+  const latestByMarket = new Map<string, (typeof priceHistory)[0]>();
+  for (const record of priceHistory) {
+    const key = record.marketplace.toLowerCase();
+    if (!latestByMarket.has(key)) {
+      latestByMarket.set(key, record);
+    }
+  }
+
+  const latestRecords = Array.from(latestByMarket.values());
+
+  // Determine the best marketplace to sell on (highest bidPrice, fallback to lastSold)
+  let bestMarketplace = "";
+  let highestValue = -1;
+  latestRecords.forEach((record) => {
+    const val = record.bidPrice ?? record.lastSold ?? 0;
+    if (val > highestValue) {
+      highestValue = val;
+      bestMarketplace = record.marketplace;
+    }
+  });
+
+  const data = latestRecords
+    .map((record) => ({
+      name: formatMarketplaceName(record.marketplace),
+      ask: record.askPrice,
+      lastSold: record.lastSold,
+      bid: record.bidPrice,
+      best: record.marketplace === bestMarketplace && highestValue > 0,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
   return (
     <div className={[styles.card, className].filter(Boolean).join(" ")}>
       <div className={styles.title}>Marketplace Comparison</div>
@@ -25,12 +89,30 @@ export function MarketplaceComparison({ className }: Props) {
           </tr>
         </thead>
         <tbody>
-          {data.map(d => (
+          {data.map((d) => (
             <tr key={d.name}>
               <td className={styles.td}>{d.name}</td>
-              <td className={styles.td}><span className={styles.mono}>${d.ask}</span></td>
-              <td className={styles.td}><span className={styles.mono}>${d.lastSold}</span></td>
-              <td className={styles.td}>{d.bid ? <span className={styles.mono}>${d.bid}</span> : <span style={{ color: "var(--color-text-subtle)" }}>N/A</span>}</td>
+              <td className={styles.td}>
+                {d.ask ? (
+                  <span className={styles.mono}>${d.ask}</span>
+                ) : (
+                  <span style={{ color: "var(--color-text-subtle)" }}>N/A</span>
+                )}
+              </td>
+              <td className={styles.td}>
+                {d.lastSold ? (
+                  <span className={styles.mono}>${d.lastSold}</span>
+                ) : (
+                  <span style={{ color: "var(--color-text-subtle)" }}>N/A</span>
+                )}
+              </td>
+              <td className={styles.td}>
+                {d.bid ? (
+                  <span className={styles.mono}>${d.bid}</span>
+                ) : (
+                  <span style={{ color: "var(--color-text-subtle)" }}>N/A</span>
+                )}
+              </td>
               <td className={styles.td}>{d.best && <span className={styles.bestBadge}>Best to Sell</span>}</td>
             </tr>
           ))}

--- a/app/blocks/inventory-item-detail/price-history-chart.tsx
+++ b/app/blocks/inventory-item-detail/price-history-chart.tsx
@@ -1,23 +1,92 @@
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from "recharts";
-import { mockPriceHistory } from "~/data/mock-data";
+import type { MarketPrice } from "@prisma/client";
 import styles from "./price-history-chart.module.css";
 
-interface Props { className?: string; }
+interface Props {
+  className?: string;
+  priceHistory: (Pick<MarketPrice, "marketplace"> & {
+    fetchedAt: string | Date;
+    askPrice: number | null;
+    bidPrice: number | null;
+    lastSold: number | null;
+  })[];
+}
 
 const marketplaceColors: Record<string, string> = {
-  stockx: "#00FF88", goat: "#7C3AED", ebay: "#3B82F6", flightclub: "#FFB347", stadiumgoods: "#FF4D6A",
+  stockx: "#00FF88",
+  goat: "#7C3AED",
+  ebay: "#3B82F6",
+  flightclub: "#FFB347",
+  stadiumgoods: "#FF4D6A",
 };
 
-export function PriceHistoryChart({ className }: Props) {
+export function PriceHistoryChart({ className, priceHistory }: Props) {
+  if (!priceHistory || priceHistory.length === 0) {
+    return (
+      <div className={[styles.card, className].filter(Boolean).join(" ")}>
+        <div className={styles.title}>30-Day Price History</div>
+        <p
+          style={{
+            fontSize: 14,
+            color: "var(--color-text-muted)",
+            textAlign: "center",
+            padding: "var(--space-6)",
+            margin: 0,
+          }}
+        >
+          No price history available.
+        </p>
+      </div>
+    );
+  }
+
+  const groupedData: Record<string, any> = {};
+
+  priceHistory.forEach((record) => {
+    const d = new Date(record.fetchedAt);
+    const dateStr = `${(d.getMonth() + 1).toString().padStart(2, "0")}/${d.getDate().toString().padStart(2, "0")}`;
+    const sortKey = d.getTime();
+
+    if (!groupedData[dateStr]) {
+      groupedData[dateStr] = { date: dateStr, _sortTime: sortKey };
+    }
+
+    const marketKey = record.marketplace.toLowerCase();
+    const price = record.lastSold ?? record.askPrice ?? record.bidPrice;
+    if (price !== null) {
+      groupedData[dateStr][marketKey] = price;
+    }
+  });
+
+  const chartData = Object.values(groupedData).sort((a, b) => a._sortTime - b._sortTime);
+
   return (
     <div className={[styles.card, className].filter(Boolean).join(" ")}>
       <div className={styles.title}>30-Day Price History</div>
       <ResponsiveContainer width="100%" height={260}>
-        <LineChart data={mockPriceHistory} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
+        <LineChart data={chartData} margin={{ top: 0, right: 0, left: 0, bottom: 0 }}>
           <CartesianGrid strokeDasharray="3 3" stroke="rgba(255,255,255,0.05)" />
-          <XAxis dataKey="date" tick={{ fill: "var(--color-text-subtle)", fontSize: 11 }} axisLine={false} tickLine={false} />
-          <YAxis tick={{ fill: "var(--color-text-subtle)", fontSize: 11 }} axisLine={false} tickLine={false} tickFormatter={v => `$${v}`} />
-          <Tooltip contentStyle={{ background: "var(--color-bg-elevated)", border: "1px solid var(--color-border)", borderRadius: 8, fontSize: 12 }} formatter={(v) => [`${Number(v)}`, ""]} />
+          <XAxis
+            dataKey="date"
+            tick={{ fill: "var(--color-text-subtle)", fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+          />
+          <YAxis
+            tick={{ fill: "var(--color-text-subtle)", fontSize: 11 }}
+            axisLine={false}
+            tickLine={false}
+            tickFormatter={(v) => `$${v}`}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "var(--color-bg-elevated)",
+              border: "1px solid var(--color-border)",
+              borderRadius: 8,
+              fontSize: 12,
+            }}
+            formatter={(v) => [`${Number(v)}`, ""]}
+          />
           <Legend wrapperStyle={{ fontSize: 11 }} />
           {Object.entries(marketplaceColors).map(([key, color]) => (
             <Line key={key} type="monotone" dataKey={key} stroke={color} strokeWidth={2} dot={false} />

--- a/app/blocks/inventory-item-detail/related-items.tsx
+++ b/app/blocks/inventory-item-detail/related-items.tsx
@@ -2,7 +2,9 @@ import { Link } from "react-router";
 import { mockInventoryItems } from "~/data/mock-data";
 import styles from "./related-items.module.css";
 
-interface Props { className?: string; }
+interface Props {
+  className?: string;
+}
 
 export function RelatedItems({ className }: Props) {
   const related = mockInventoryItems.slice(1, 5);
@@ -10,7 +12,7 @@ export function RelatedItems({ className }: Props) {
     <div className={[styles.section, className].filter(Boolean).join(" ")}>
       <div className={styles.title}>Related Items</div>
       <div className={styles.grid}>
-        {related.map(item => (
+        {related.map((item) => (
           <Link key={item.id} to={`/app/inventory/${item.id}`} className={styles.card}>
             <div className={styles.image}>Image</div>
             <div className={styles.name}>{item.name}</div>

--- a/app/blocks/inventory-item-detail/sales-history.tsx
+++ b/app/blocks/inventory-item-detail/sales-history.tsx
@@ -1,12 +1,76 @@
+import type { Sale } from "@prisma/client";
 import styles from "./sales-history.module.css";
 
-interface Props { className?: string; }
+interface Props {
+  className?: string;
+  sale:
+    | (Pick<Sale, "marketplace" | "currency" | "buyerHandle" | "trackingNumber" | "notes"> & {
+        salePrice: number;
+        saleDate: string | Date;
+      })
+    | null;
+}
 
-export function SalesHistory({ className }: Props) {
+export function SalesHistory({ className, sale }: Props) {
+  if (!sale) {
+    return (
+      <div className={[styles.card, className].filter(Boolean).join(" ")}>
+        <div className={styles.title}>Sales History</div>
+        <p className={styles.empty}>This item has not been sold yet.</p>
+      </div>
+    );
+  }
+
+  const formattedSaleDate = new Date(sale.saleDate).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+
+  const displayMarketplace = sale.marketplace
+    .replace(/_/g, " ")
+    .toLowerCase()
+    .replace(/\b\w/g, (l) => l.toUpperCase());
+
+  const formatMoney = (val: number, currency: string = "USD") => {
+    return new Intl.NumberFormat("en-US", { style: "currency", currency }).format(val);
+  };
+
   return (
     <div className={[styles.card, className].filter(Boolean).join(" ")}>
       <div className={styles.title}>Sales History</div>
-      <p className={styles.empty}>This item has not been sold yet.</p>
+      <div className={styles.row}>
+        <div className={styles.field}>
+          <div className={styles.label}>Sale Date</div>
+          <div className={styles.value}>{formattedSaleDate}</div>
+        </div>
+        <div className={styles.field}>
+          <div className={styles.label}>Sale Price</div>
+          <div className={[styles.value, styles.profit].join(" ")}>{formatMoney(sale.salePrice, sale.currency)}</div>
+        </div>
+        <div className={styles.field}>
+          <div className={styles.label}>Marketplace</div>
+          <div className={styles.value}>{displayMarketplace}</div>
+        </div>
+        {sale.buyerHandle && (
+          <div className={styles.field}>
+            <div className={styles.label}>Buyer</div>
+            <div className={styles.value}>{sale.buyerHandle}</div>
+          </div>
+        )}
+        {sale.trackingNumber && (
+          <div className={styles.field}>
+            <div className={styles.label}>Tracking</div>
+            <div className={styles.value}>{sale.trackingNumber}</div>
+          </div>
+        )}
+        {sale.notes && (
+          <div className={styles.field}>
+            <div className={styles.label}>Notes</div>
+            <div className={styles.value}>{sale.notes}</div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/app/routes/inventory-item-detail.tsx
+++ b/app/routes/inventory-item-detail.tsx
@@ -3,6 +3,12 @@ import type { Route } from "./+types/inventory-item-detail";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
 import { PrismaClient } from "@prisma/client";
 import styles from "./inventory-item-detail.module.css";
+import { ItemHeader } from "~/blocks/inventory-item-detail/item-header";
+import { ItemInfoCard } from "~/blocks/inventory-item-detail/item-info-card";
+import { PriceHistoryChart } from "~/blocks/inventory-item-detail/price-history-chart";
+import { MarketplaceComparison } from "~/blocks/inventory-item-detail/marketplace-comparison";
+import { SalesHistory } from "~/blocks/inventory-item-detail/sales-history";
+import { RelatedItems } from "~/blocks/inventory-item-detail/related-items";
 
 const prisma = new PrismaClient();
 
@@ -21,7 +27,7 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  const item = await prisma.inventoryItem.findUnique({
+  const item = await prisma.inventoryItem.findFirst({
     where: {
       id,
       userId: user.id,
@@ -58,12 +64,6 @@ export async function loader({ request, params }: Route.LoaderArgs) {
     },
   };
 }
-import { ItemHeader } from "~/blocks/inventory-item-detail/item-header";
-import { ItemInfoCard } from "~/blocks/inventory-item-detail/item-info-card";
-import { PriceHistoryChart } from "~/blocks/inventory-item-detail/price-history-chart";
-import { MarketplaceComparison } from "~/blocks/inventory-item-detail/marketplace-comparison";
-import { SalesHistory } from "~/blocks/inventory-item-detail/sales-history";
-import { RelatedItems } from "~/blocks/inventory-item-detail/related-items";
 
 export default function InventoryItemDetailPage() {
   const { item } = useLoaderData<typeof loader>();

--- a/app/routes/inventory-item-detail.tsx
+++ b/app/routes/inventory-item-detail.tsx
@@ -1,4 +1,63 @@
+import { useLoaderData } from "react-router";
+import type { Route } from "./+types/inventory-item-detail";
+import { getSupabaseServerClient } from "~/utils/supabase.server";
+import { PrismaClient } from "@prisma/client";
 import styles from "./inventory-item-detail.module.css";
+
+const prisma = new PrismaClient();
+
+export async function loader({ request, params }: Route.LoaderArgs) {
+  const { supabase } = getSupabaseServerClient(request);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Response("Unauthorized", { status: 401 });
+  }
+
+  const { id } = params;
+  if (!id) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  const item = await prisma.inventoryItem.findUnique({
+    where: {
+      id,
+      userId: user.id,
+    },
+    include: {
+      sale: true,
+      priceHistory: {
+        orderBy: { fetchedAt: "desc" },
+      },
+    },
+  });
+
+  if (!item) {
+    throw new Response("Not Found", { status: 404 });
+  }
+
+  return {
+    item: {
+      ...item,
+      purchasePrice: Number(item.purchasePrice),
+      askingPrice: item.askingPrice ? Number(item.askingPrice) : null,
+      sale: item.sale
+        ? {
+            ...item.sale,
+            salePrice: Number(item.sale.salePrice),
+          }
+        : null,
+      priceHistory: item.priceHistory.map((ph) => ({
+        ...ph,
+        askPrice: ph.askPrice ? Number(ph.askPrice) : null,
+        bidPrice: ph.bidPrice ? Number(ph.bidPrice) : null,
+        lastSold: ph.lastSold ? Number(ph.lastSold) : null,
+      })),
+    },
+  };
+}
 import { ItemHeader } from "~/blocks/inventory-item-detail/item-header";
 import { ItemInfoCard } from "~/blocks/inventory-item-detail/item-info-card";
 import { PriceHistoryChart } from "~/blocks/inventory-item-detail/price-history-chart";
@@ -7,15 +66,23 @@ import { SalesHistory } from "~/blocks/inventory-item-detail/sales-history";
 import { RelatedItems } from "~/blocks/inventory-item-detail/related-items";
 
 export default function InventoryItemDetailPage() {
+  const { item } = useLoaderData<typeof loader>();
   return (
     <div className={styles.page}>
-      <ItemHeader />
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 2fr", gap: "var(--space-6)", marginBottom: "var(--space-6)" }}>
-        <ItemInfoCard />
-        <PriceHistoryChart />
+      <ItemHeader item={item} />
+      <div
+        style={{
+          display: "grid",
+          gridTemplateColumns: "1fr 2fr",
+          gap: "var(--space-6)",
+          marginBottom: "var(--space-6)",
+        }}
+      >
+        <ItemInfoCard item={item} />
+        <PriceHistoryChart priceHistory={item.priceHistory} />
       </div>
-      <MarketplaceComparison />
-      <SalesHistory />
+      <MarketplaceComparison priceHistory={item.priceHistory} />
+      <SalesHistory sale={item.sale} />
       <RelatedItems />
     </div>
   );


### PR DESCRIPTION
## Description

This PR replaces the static Inventory Item Detail page with live data fetched from the Prisma database. The page now dynamically renders inventory details, sale information, price history, and marketplace comparisons while preserving the existing UI and handling empty states gracefully.

Key changes:
- Added a Remix loader to fetch inventory item data from Prisma.
- Replaced hardcoded values with dynamic data.
- Connected the page to authenticated user-scoped data.
- Updated Price History Chart to use live market price history.
- Updated Marketplace Comparison to display dynamic marketplace data.
- Added proper null handling and empty-state rendering.

## Related Issues

Fixes #4

Submitted as part of **ECSoC'26**.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots (if applicable)

N/A