### PR TITLE
fix: prevent IDOR when logging a sale for an inventory item

### DIFF
--- a/app/routes/sales-log.tsx
+++ b/app/routes/sales-log.tsx
@@ -100,6 +100,13 @@ export async function action({ request }: Route.ActionArgs) {
     const marketplace = formData.get("marketplace") as any;
     const trackingNumber = formData.get("trackingNumber") as string;
 
+    // formData.get() can return null (missing field) or a File; the `as string`
+    // cast hides that from tsc but Prisma would throw a 500 at runtime. Validate
+    // the type up front so a malformed request fails gracefully with a 400.
+    if (typeof inventoryItemId !== "string" || !inventoryItemId) {
+      return new Response("Bad Request", { status: 400 });
+    }
+
     // Verify the item belongs to the current user before logging a sale against it,
     // otherwise a tampered request could mark another user's inventory as sold.
     const ownedItem = await prisma.inventoryItem.findFirst({

--- a/app/routes/sales-log.tsx
+++ b/app/routes/sales-log.tsx
@@ -100,6 +100,16 @@ export async function action({ request }: Route.ActionArgs) {
     const marketplace = formData.get("marketplace") as any;
     const trackingNumber = formData.get("trackingNumber") as string;
 
+    // Verify the item belongs to the current user before logging a sale against it,
+    // otherwise a tampered request could mark another user's inventory as sold.
+    const ownedItem = await prisma.inventoryItem.findFirst({
+      where: { id: inventoryItemId, userId: user.id },
+      select: { id: true },
+    });
+    if (!ownedItem) {
+      return new Response("Not Found", { status: 404 });
+    }
+
     await prisma.$transaction([
       prisma.sale.create({
         data: {
@@ -112,7 +122,7 @@ export async function action({ request }: Route.ActionArgs) {
         },
       }),
       prisma.inventoryItem.update({
-        where: { id: inventoryItemId },
+        where: { id: inventoryItemId, userId: user.id },
         data: { status: "SOLD" },
       }),
     ]);


### PR DESCRIPTION
Fixes #67

Adds an ownership check before marking an inventory item SOLD in the sales-log "create" action. Previously `inventoryItemId` was trusted straight from form data and updated with no `userId` scoping, unlike every sibling action in this file — a tampered request could mark another user's item as sold. Now `findFirst({ where: { id, userId } })` is checked first (404 if not owned), and the transaction's update is scoped by `userId` too as defense-in-depth.
