### PR TITLE
feat: Build Tax Report Loader & Connect Real Data #22

### DIFF
--- a/app/blocks/tax-report-export/export-options.tsx
+++ b/app/blocks/tax-report-export/export-options.tsx
@@ -1,30 +1,67 @@
 import styles from "./export-options.module.css";
 
-interface Props { className?: string; }
+interface Props {
+  taxYear: number;
+  className?: string;
+}
 
-const options = [
-  { icon: "📄", label: "CSV Export", desc: "For spreadsheets" },
-  { icon: "📊", label: "PDF Report", desc: "For accountants" },
-  { icon: "📝", label: "Form 8949", desc: "US tax template" },
-];
-
-export function ExportOptions({ className }: Props) {
+export function ExportOptions({ taxYear, className }: Props) {
   return (
     <div className={[styles.section, className].filter(Boolean).join(" ")}>
-      <a href="/api/export/tax" download className={styles.btn} style={{ textDecoration: 'none', color: 'inherit' }}>
+      <a
+        href={`/api/export/tax?year=${taxYear}`}
+        download
+        className={styles.btn}
+        style={{ textDecoration: "none", color: "inherit" }}
+      >
         <span className={styles.btnIcon}>📄</span>
         CSV Export
-        <span style={{ fontSize: 11, color: "var(--color-text-subtle)", display: 'block', marginTop: '2px' }}>For spreadsheets</span>
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--color-text-subtle)",
+            display: "block",
+            marginTop: "2px",
+          }}
+        >
+          For spreadsheets
+        </span>
       </a>
-      <button className={styles.btn} disabled style={{ opacity: 0.5, cursor: 'not-allowed' }}>
+      <button
+        className={styles.btn}
+        disabled
+        style={{ opacity: 0.5, cursor: "not-allowed" }}
+      >
         <span className={styles.btnIcon}>📊</span>
         PDF Report
-        <span style={{ fontSize: 11, color: "var(--color-text-subtle)", display: 'block', marginTop: '2px' }}>Coming soon</span>
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--color-text-subtle)",
+            display: "block",
+            marginTop: "2px",
+          }}
+        >
+          Coming soon
+        </span>
       </button>
-      <button className={styles.btn} disabled style={{ opacity: 0.5, cursor: 'not-allowed' }}>
+      <button
+        className={styles.btn}
+        disabled
+        style={{ opacity: 0.5, cursor: "not-allowed" }}
+      >
         <span className={styles.btnIcon}>📝</span>
         Form 8949
-        <span style={{ fontSize: 11, color: "var(--color-text-subtle)", display: 'block', marginTop: '2px' }}>Coming soon</span>
+        <span
+          style={{
+            fontSize: 11,
+            color: "var(--color-text-subtle)",
+            display: "block",
+            marginTop: "2px",
+          }}
+        >
+          Coming soon
+        </span>
       </button>
     </div>
   );

--- a/app/blocks/tax-report-export/report-generator.tsx
+++ b/app/blocks/tax-report-export/report-generator.tsx
@@ -1,21 +1,53 @@
+import { useNavigate, useSearchParams } from "react-router";
 import styles from "./report-generator.module.css";
 
-interface Props { className?: string; }
+interface Props {
+  taxYear: number;
+  className?: string;
+}
 
-export function ReportGenerator({ className }: Props) {
+const currentYear = new Date().getFullYear();
+const years = Array.from({ length: 5 }, (_, i) => currentYear - i);
+
+export function ReportGenerator({ taxYear, className }: Props) {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  function handleYearChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    const params = new URLSearchParams(searchParams);
+    params.set("year", e.target.value);
+    navigate(`?${params.toString()}`, { replace: true });
+  }
+
   return (
     <div className={[styles.card, className].filter(Boolean).join(" ")}>
       <div className={styles.title}>Generate Tax Report</div>
       <div className={styles.form}>
         <div className={styles.field}>
-          <label className={styles.label}>Tax Year</label>
-          <select className={styles.select}><option>2024</option><option>2023</option><option>2022</option></select>
+          <label className={styles.label} htmlFor="tax-year-select">
+            Tax Year
+          </label>
+          <select
+            id="tax-year-select"
+            className={styles.select}
+            value={taxYear}
+            onChange={handleYearChange}
+          >
+            {years.map((y) => (
+              <option key={y} value={y}>
+                {y}
+              </option>
+            ))}
+          </select>
         </div>
         <div className={styles.field}>
           <label className={styles.label}>Currency</label>
-          <select className={styles.select}><option>USD ($)</option><option>CAD (CA$)</option><option>GBP (£)</option></select>
+          <select className={styles.select}>
+            <option>USD ($)</option>
+            <option>CAD (CA$)</option>
+            <option>GBP (£)</option>
+          </select>
         </div>
-        <button className={styles.generateBtn}>Generate Report</button>
       </div>
     </div>
   );

--- a/app/blocks/tax-report-export/report-preview.tsx
+++ b/app/blocks/tax-report-export/report-preview.tsx
@@ -1,46 +1,165 @@
-import { mockSales } from "~/data/mock-data";
 import styles from "./report-preview.module.css";
 
-interface Props { className?: string; }
+interface SaleRow {
+  id: string;
+  saleDate: string | Date;
+  salePrice: number;
+  inventoryItem: {
+    name: string;
+    sku: string;
+    purchasePrice: number;
+  };
+}
 
-export function ReportPreview({ className }: Props) {
-  const totalProceeds = mockSales.reduce((s, sale) => s + sale.salePrice, 0);
-  const totalGains = mockSales.reduce((s, sale) => s + sale.profit, 0);
+interface ExpenseRow {
+  id: string;
+  date: string | Date;
+  description: string | null;
+  type: string;
+  amount: number;
+}
+
+interface Props {
+  sales: SaleRow[];
+  expenses: ExpenseRow[];
+  taxYear: number;
+  className?: string;
+}
+
+export function ReportPreview({ sales, expenses, taxYear, className }: Props) {
+  const totalProceeds = sales.reduce((s, sale) => s + sale.salePrice, 0);
+  const totalCostBasis = sales.reduce(
+    (s, sale) => s + sale.inventoryItem.purchasePrice,
+    0
+  );
+  const totalGains = totalProceeds - totalCostBasis;
+  const totalExpenses = expenses.reduce((s, exp) => s + exp.amount, 0);
+
+  const formatDate = (d: string | Date) =>
+    new Date(d).toISOString().split("T")[0];
 
   return (
     <div className={[styles.card, className].filter(Boolean).join(" ")}>
       <div className={styles.header}>
-        <div className={styles.title}>Preview — Tax Year 2024</div>
+        <div className={styles.title}>Preview — Tax Year {taxYear}</div>
         <div className={styles.summaryRow}>
-          <div className={styles.summaryCard}><div className={styles.summaryLabel}>Total Proceeds</div><div className={styles.summaryValue}>${totalProceeds.toLocaleString()}</div></div>
-          <div className={styles.summaryCard}><div className={styles.summaryLabel}>Total Cost Basis</div><div className={styles.summaryValue}>${(totalProceeds - totalGains).toLocaleString()}</div></div>
-          <div className={styles.summaryCard}><div className={styles.summaryLabel}>Net Capital Gains</div><div className={[styles.summaryValue, styles.positive].join(" ")}>${totalGains.toLocaleString()}</div></div>
+          <div className={styles.summaryCard}>
+            <div className={styles.summaryLabel}>Total Proceeds</div>
+            <div className={styles.summaryValue}>
+              ${totalProceeds.toLocaleString()}
+            </div>
+          </div>
+          <div className={styles.summaryCard}>
+            <div className={styles.summaryLabel}>Total Cost Basis</div>
+            <div className={styles.summaryValue}>
+              ${totalCostBasis.toLocaleString()}
+            </div>
+          </div>
+          <div className={styles.summaryCard}>
+            <div className={styles.summaryLabel}>Net Capital Gains</div>
+            <div
+              className={[
+                styles.summaryValue,
+                totalGains >= 0 ? styles.positive : styles.negative,
+              ].join(" ")}
+            >
+              {totalGains >= 0 ? "+" : ""}${totalGains.toLocaleString()}
+            </div>
+          </div>
+          <div className={styles.summaryCard}>
+            <div className={styles.summaryLabel}>Total Deductible Expenses</div>
+            <div className={[styles.summaryValue, styles.negative].join(" ")}>
+              -${totalExpenses.toLocaleString()}
+            </div>
+          </div>
         </div>
       </div>
-      <div className={styles.tableWrap}>
-        <table className={styles.table}>
-          <thead>
-            <tr>
-              <th className={styles.th}>Date</th>
-              <th className={styles.th}>Item</th>
-              <th className={styles.th}>Proceeds</th>
-              <th className={styles.th}>Cost Basis</th>
-              <th className={styles.th}>Gain/Loss</th>
-            </tr>
-          </thead>
-          <tbody>
-            {mockSales.map(s => (
-              <tr key={s.id} className={styles.tr}>
-                <td className={styles.td}>{s.date}</td>
-                <td className={styles.td}>{s.item}</td>
-                <td className={styles.td}><span className={styles.mono}>${s.salePrice}</span></td>
-                <td className={styles.td}><span className={styles.mono}>${s.salePrice - s.profit}</span></td>
-                <td className={styles.td}><span className={[styles.mono, s.profit >= 0 ? styles.positive : styles.negative].join(" ")}>{s.profit >= 0 ? "+" : ""}${s.profit}</span></td>
+
+      {sales.length === 0 && expenses.length === 0 ? (
+        <div
+          style={{
+            padding: "var(--space-8)",
+            textAlign: "center",
+            color: "var(--color-text-subtle)",
+            fontSize: 14,
+          }}
+        >
+          No sales or expenses recorded for {taxYear}.
+        </div>
+      ) : (
+        <div className={styles.tableWrap}>
+          <table className={styles.table}>
+            <thead>
+              <tr>
+                <th className={styles.th}>Date</th>
+                <th className={styles.th}>Type</th>
+                <th className={styles.th}>Item / Description</th>
+                <th className={styles.th}>Proceeds</th>
+                <th className={styles.th}>Cost Basis</th>
+                <th className={styles.th}>Gain / Loss</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {sales.map((s) => {
+                const gain = s.salePrice - s.inventoryItem.purchasePrice;
+                return (
+                  <tr key={s.id} className={styles.tr}>
+                    <td className={styles.td}>{formatDate(s.saleDate)}</td>
+                    <td className={styles.td}>Sale</td>
+                    <td className={styles.td}>
+                      {s.inventoryItem.name}{" "}
+                      <span style={{ color: "var(--color-text-subtle)" }}>
+                        ({s.inventoryItem.sku})
+                      </span>
+                    </td>
+                    <td className={styles.td}>
+                      <span className={styles.mono}>${s.salePrice}</span>
+                    </td>
+                    <td className={styles.td}>
+                      <span className={styles.mono}>
+                        ${s.inventoryItem.purchasePrice}
+                      </span>
+                    </td>
+                    <td className={styles.td}>
+                      <span
+                        className={[
+                          styles.mono,
+                          gain >= 0 ? styles.positive : styles.negative,
+                        ].join(" ")}
+                      >
+                        {gain >= 0 ? "+" : ""}${gain}
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+              {expenses.map((e) => (
+                <tr key={e.id} className={styles.tr}>
+                  <td className={styles.td}>{formatDate(e.date)}</td>
+                  <td className={styles.td}>Expense</td>
+                  <td className={styles.td}>
+                    {e.description || e.type}{" "}
+                    <span style={{ color: "var(--color-text-subtle)" }}>
+                      ({e.type})
+                    </span>
+                  </td>
+                  <td className={styles.td}>
+                    <span className={styles.mono}>—</span>
+                  </td>
+                  <td className={styles.td}>
+                    <span className={styles.mono}>—</span>
+                  </td>
+                  <td className={styles.td}>
+                    <span className={[styles.mono, styles.negative].join(" ")}>
+                      -${e.amount}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   );
 }

--- a/app/routes/tax-report-export.tsx
+++ b/app/routes/tax-report-export.tsx
@@ -1,3 +1,8 @@
+import { useLoaderData } from "react-router";
+import type { Route } from "./+types/tax-report-export";
+import { getSupabaseServerClient } from "~/utils/supabase.server";
+import { PrismaClient } from "@prisma/client";
+import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
 import styles from "./tax-report-export.module.css";
 import { TaxReportHeader } from "~/blocks/tax-report-export/tax-report-header";
 import { ReportGenerator } from "~/blocks/tax-report-export/report-generator";
@@ -5,13 +10,80 @@ import { ReportPreview } from "~/blocks/tax-report-export/report-preview";
 import { ExportOptions } from "~/blocks/tax-report-export/export-options";
 import { ReportHistory } from "~/blocks/tax-report-export/report-history";
 
+export function headers(_: Route.HeadersArgs) {
+  return {
+    "Cache-Control": CACHE_PRIVATE_NO_STORE,
+  };
+}
+
+const prisma = new PrismaClient();
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const { supabase } = getSupabaseServerClient(request);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  const currentYear = new Date().getFullYear();
+
+  if (!user) {
+    return { sales: [], expenses: [], taxYear: currentYear };
+  }
+
+  const url = new URL(request.url);
+  const taxYear = Number(url.searchParams.get("year")) || currentYear;
+
+  const startDate = new Date(`${taxYear}-01-01T00:00:00Z`);
+  const endDate = new Date(`${taxYear}-12-31T23:59:59Z`);
+
+  const [sales, expenses] = await Promise.all([
+    prisma.sale.findMany({
+      where: {
+        userId: user.id,
+        saleDate: { gte: startDate, lte: endDate },
+      },
+      include: { inventoryItem: true },
+      orderBy: { saleDate: "asc" },
+    }),
+    prisma.expense.findMany({
+      where: {
+        userId: user.id,
+        date: { gte: startDate, lte: endDate },
+      },
+      orderBy: { date: "asc" },
+    }),
+  ]);
+
+  // Serialize Prisma Decimal fields before passing to client components
+  const serializedSales = sales.map((s) => ({
+    ...s,
+    salePrice: Number(s.salePrice),
+    inventoryItem: {
+      ...s.inventoryItem,
+      purchasePrice: Number(s.inventoryItem.purchasePrice),
+      askingPrice: s.inventoryItem.askingPrice
+        ? Number(s.inventoryItem.askingPrice)
+        : null,
+    },
+  }));
+
+  const serializedExpenses = expenses.map((e) => ({
+    ...e,
+    amount: Number(e.amount),
+  }));
+
+  return { sales: serializedSales, expenses: serializedExpenses, taxYear };
+}
+
 export default function TaxReportExportPage() {
+  const { sales, expenses, taxYear } = useLoaderData<typeof loader>();
+
   return (
     <div className={styles.page}>
       <TaxReportHeader />
-      <ReportGenerator />
-      <ReportPreview />
-      <ExportOptions />
+      <ReportGenerator taxYear={taxYear} />
+      <ReportPreview sales={sales} expenses={expenses} taxYear={taxYear} />
+      <ExportOptions taxYear={taxYear} />
       <ReportHistory />
     </div>
   );


### PR DESCRIPTION
## Description

The Tax Report page (`/app/tax-report`) previously had no `loader` function and relied entirely on static `mockSales` from `~/data/mock-data.ts`, meaning every user saw identical hardcoded data regardless of their actual account.

This PR replaces all mock data with a real React Router v7 `loader` that fetches the authenticated user's sales and expenses from the database for the selected tax year, then passes that live data down to the UI components.

**Changes made:**

- **`app/routes/tax-report-export.tsx`** — Added `loader` + `headers` exports. The loader authenticates via Supabase, reads a `?year=` query param (defaulting to the current year), queries Prisma for `Sale` records (with `inventoryItem` included) and `Expense` records scoped to that year's date range, serializes all `Decimal` fields with `Number()` per the project convention, and returns `{ sales, expenses, taxYear }` to the page component. Unauthenticated users get safe empty arrays.

- **`app/blocks/tax-report-export/report-preview.tsx`** — Removed `import { mockSales }`. Now accepts `sales`, `expenses`, and `taxYear` as props. The summary row now includes a **Total Deductible Expenses** card. The table shows both sale rows and expense rows in a unified view. An empty state is rendered when no data exists for the selected year.

- **`app/blocks/tax-report-export/report-generator.tsx`** — Accepts `taxYear` prop. The year `<select>` uses `useNavigate` to update `?year=` in the URL on change, which triggers the loader to re-fetch — consistent with the navigation pattern used elsewhere in the codebase. Year list is dynamically generated for the last 5 years.

- **`app/blocks/tax-report-export/export-options.tsx`** — The CSV download href now includes `?year=${taxYear}` so the exported file always corresponds to the year currently being previewed.

## Related Issues

Fixes #22

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

> **Before:** The page always displayed the same 5 hardcoded mock sales for "Tax Year 2024" regardless of which user was logged in or which year was selected.
>
> **After:** The page loads real sales and expenses from the database for the authenticated user, filtered by the selected year. The year selector updates the URL (`?year=YYYY`) and triggers a server-side re-fetch. An empty state is shown gracefully when no data exists for a given year. The CSV export button passes the correct year to `/api/export/tax?year=YYYY`.
