### PR TITLE
feat(error-boundary): improve global error boundary UX with theme tokens and recovery actions

### DIFF
--- a/app/components/error-boundary/error-boundary.module.css
+++ b/app/components/error-boundary/error-boundary.module.css
@@ -3,57 +3,131 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: var(--space-8) var(--space-6);
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--family-body);
 }
 
 .errorContainer {
   text-align: center;
-  max-width: 70%;
+  max-width: 32rem;
   width: 100%;
-  padding: 2.5rem;
+  padding: var(--space-10) var(--space-8);
+  background: var(--color-bg-elevated);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+}
+
+.iconWrapper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 4rem;
+  height: 4rem;
+  margin-bottom: var(--space-4);
+  border-radius: var(--radius-full);
+  background: var(--color-danger-bg);
+  color: var(--color-danger);
 }
 
 .errorTitle {
-  font-weight: bold;
-  margin-bottom: 0.5rem;
-  font-size: 3rem;
-  color: #333;
+  font-weight: 700;
+  margin-bottom: var(--space-2);
+  font-size: 1.75rem;
+  color: var(--color-text);
+}
+
+.errorDetails {
+  color: var(--color-text-muted);
+  font-size: 1rem;
+  line-height: 1.5;
+  margin-bottom: var(--space-6);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-2);
+}
+
+.primaryButton,
+.secondaryButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0.625rem var(--space-5);
+  border-radius: var(--radius-md);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition:
+    background var(--transition-fast),
+    border-color var(--transition-fast);
+  border: 1px solid transparent;
+}
+
+.primaryButton {
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+}
+
+.primaryButton:hover {
+  background: var(--color-primary-dark);
+}
+
+.secondaryButton {
+  background: transparent;
+  color: var(--color-text);
+  border-color: var(--color-border-strong);
+}
+
+.secondaryButton:hover {
+  background: var(--color-bg-hover);
 }
 
 .errorStackWrapper {
   position: relative;
+  margin-top: var(--space-6);
 }
 
 .copyButton {
   position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background: #e5e5e5;
-  border: 1px solid #d4d4d4;
-  border-radius: 0.25rem;
+  top: var(--space-2);
+  right: var(--space-2);
+  padding: var(--space-1) var(--space-3);
+  background: var(--color-bg-card);
+  border: 1px solid var(--color-border-strong);
+  border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: 0.75rem;
   font-weight: 500;
-  color: #333;
+  color: var(--color-text);
 }
 
 .copyButton:hover {
-  background: #d4d4d4;
+  background: var(--color-bg-hover);
 }
 
 .copyButton:active {
-  background: #c4c4c4;
+  background: var(--color-bg-hover);
 }
 
 .errorStack {
-  margin-top: 1rem;
+  margin-top: var(--space-4);
   text-align: start;
   overflow: auto;
-  font-size: 0.875rem;
-  padding: 1rem;
-  background: #f5f5f5;
-  border-radius: 0.375rem;
-  border: 1px solid #e5e5e5;
+  font-family: var(--family-mono);
+  font-size: 0.8rem;
+  padding: var(--space-4);
+  background: var(--color-bg-card);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  color: var(--color-text-muted);
   max-height: 20rem;
 }

--- a/app/components/error-boundary/error-boundary.tsx
+++ b/app/components/error-boundary/error-boundary.tsx
@@ -1,35 +1,86 @@
-import { isRouteErrorResponse } from "react-router";
+import { useEffect, useState } from "react";
+import { isRouteErrorResponse, Link } from "react-router";
+import { IconAlertTriangle, IconHome, IconRefresh } from "@tabler/icons-react";
 import type { Route } from "../../+types/root";
 import styles from "./error-boundary.module.css";
 
+const STATUS_COPY: Record<number, { title: string; description: string }> = {
+  400: {
+    title: "Bad request",
+    description: "That request could not be processed. Please check the details and try again.",
+  },
+  401: {
+    title: "Sign in required",
+    description: "You need to be signed in to view this page.",
+  },
+  403: {
+    title: "Access denied",
+    description: "You do not have permission to view this page.",
+  },
+  404: {
+    title: "Page not found",
+    description: "The page you are looking for does not exist or may have been moved.",
+  },
+  500: {
+    title: "Server error",
+    description: "Something went wrong on our end. Please try again in a moment.",
+  },
+};
+
 export function ErrorBoundary({ error }: Route.ErrorBoundaryProps) {
-  let message = "Oops!";
-  let details = "An unexpected error occurred.";
+  const [copied, setCopied] = useState(false);
+
+  let title = "Something went wrong";
+  let description = "An unexpected error occurred. Please try again.";
   let stack: string | undefined;
 
   if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? "404" : "Error";
-    details = error.status === 404 ? "The requested page could not be found." : error.statusText || details;
-  } else if (import.meta.env.DEV && error && error instanceof Error) {
-    details = error.message;
-    stack = error.stack;
+    const copy = STATUS_COPY[error.status];
+    title = copy ? copy.title : "Error " + error.status;
+    description = copy ? copy.description : error.statusText || description;
+  } else if (error instanceof Error) {
+    if (import.meta.env.DEV) {
+      description = error.message || description;
+      stack = error.stack;
+    }
   }
+
+  useEffect(() => {
+    console.error("[ErrorBoundary] Caught an error:", error);
+  }, [error]);
+
+  const handleCopy = () => {
+    if (!stack) return;
+    navigator.clipboard.writeText(stack);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
 
   return (
     <main className={styles.errorBoundary}>
       <div className={styles.errorContainer}>
-        <h1 className={styles.errorTitle}>{message}</h1>
-        <p className={styles.errorDetails}>{details}</p>
+        <div className={styles.iconWrapper}>
+          <IconAlertTriangle size={40} stroke={1.5} />
+        </div>
+
+        <h1 className={styles.errorTitle}>{title}</h1>
+        <p className={styles.errorDetails}>{description}</p>
+
+        <div className={styles.actions}>
+          <button className={styles.primaryButton} onClick={() => window.location.reload()}>
+            <IconRefresh size={18} stroke={1.75} />
+            Reload page
+          </button>
+          <Link to="/" className={styles.secondaryButton}>
+            <IconHome size={18} stroke={1.75} />
+            Go to homepage
+          </Link>
+        </div>
 
         {stack && (
           <div className={styles.errorStackWrapper}>
-            <button
-              className={styles.copyButton}
-              onClick={() => {
-                navigator.clipboard.writeText(stack);
-              }}
-            >
-              Copy
+            <button className={styles.copyButton} onClick={handleCopy}>
+              {copied ? "Copied!" : "Copy"}
             </button>
             <pre className={styles.errorStack}>
               <code>{stack}</code>


### PR DESCRIPTION
## Description
FlipTrack already had a global `ErrorBoundary` wired up at the root route (`app/root.tsx` → `app/components/error-boundary/error-boundary.tsx`), which handles uncaught runtime errors and route-level loader/action errors across the app. This PR builds on that existing boundary to close the remaining gaps called out in the issue:

- **Theme consistency**: The error UI used hardcoded hex colors (`#333`, `#e5e5e5`, `#f5f5f5`, etc.) instead of the project's design tokens, so it looked broken/inconsistent in dark mode (the app's default theme) and didn't follow the "never use hardcoded hex values" rule in CONTRIBUTING.md. Replaced all colors, spacing, and radii with `var(--color-*)`, `var(--space-*)`, `var(--radius-*)` tokens so it now respects both light and dark themes.
- **Friendlier messaging**: Replaced the generic "Oops!" / "Error" text with specific, user-friendly titles and descriptions for common HTTP status codes (400, 401, 403, 404, 500).
- **Debuggability**: The caught error was never logged anywhere — it only appeared inline in the UI (and only in dev). Added a `console.error` call so every caught error is visible in the console/logs regardless of environment, which also makes it easy to wire up an error-monitoring service (e.g. Sentry) later.
- **Recovery actions**: Users had no way to recover from the error page besides manually navigating away. Added "Reload page" and "Go to homepage" buttons.
- **Safety preserved**: Full error message + stack trace are still shown only when `import.meta.env.DEV` is true — never leaked in production.

## Related Issues
Closes #82

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)
<img width="1037" height="832" alt="WhatsApp Image 2026-07-04 at 12 01 32" src="https://github.com/user-attachments/assets/a2de7f9a-b1f8-41a7-aafa-b691e1149132" />
<img width="1043" height="846" alt="WhatsApp Image 2026-07-04 at 12 02 03" src="https://github.com/user-attachments/assets/6f36d194-6196-4b44-84d1-ca2139f24e12" />
