### PR TITLE
Replace vulnerable xlsx dependency with read-excel-file

### DIFF
--- a/app/blocks/inventory-management/import-excel-modal.tsx
+++ b/app/blocks/inventory-management/import-excel-modal.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useSubmit } from "react-router";
-import * as XLSX from "xlsx";
+import { readSheet } from "read-excel-file/browser";
 import { toast } from "sonner";
 import { IconX, IconUpload } from "@tabler/icons-react";
 import styles from "./import-excel-modal.module.css";
@@ -133,6 +133,78 @@ function normalizeCurrency(value: unknown) {
   }
 }
 
+function parseCSV(text: string): string[][] {
+  const result: string[][] = [];
+  let row: string[] = [];
+  let entry = "";
+  let insideQuote = false;
+  let i = 0;
+
+  while (i < text.length) {
+    const char = text[i];
+    const nextChar = text[i + 1];
+
+    if (insideQuote) {
+      if (char === '"') {
+        if (nextChar === '"') {
+          entry += '"';
+          i += 2;
+        } else {
+          insideQuote = false;
+          i++;
+        }
+      } else {
+        entry += char;
+        i++;
+      }
+    } else {
+      if (char === '"') {
+        insideQuote = true;
+        i++;
+      } else if (char === ',') {
+        row.push(entry);
+        entry = "";
+        i++;
+      } else if (char === '\r' || char === '\n') {
+        row.push(entry);
+        entry = "";
+        result.push(row);
+        row = [];
+        if (char === '\r' && nextChar === '\n') {
+          i += 2;
+        } else {
+          i++;
+        }
+      } else {
+        entry += char;
+        i++;
+      }
+    }
+  }
+
+  const endedWithNewline = text.endsWith('\n') || text.endsWith('\r');
+  if (text.length > 0 && !endedWithNewline) {
+    row.push(entry);
+    result.push(row);
+  }
+
+  return result;
+}
+
+function sheetToJSON(rows: unknown[][]): Record<string, unknown>[] {
+  if (rows.length === 0) return [];
+  const headers = rows[0].map((h) => String(h || "").trim());
+  return rows.slice(1).map((row) => {
+    const obj: Record<string, unknown> = {};
+    headers.forEach((header, index) => {
+      if (header) {
+        obj[header] = row[index] !== undefined ? row[index] : null;
+      }
+    });
+    return obj;
+  });
+}
+
 function parseSpreadsheetRows(rows: Record<string, unknown>[]) {
   const parsedItems: ParsedImportItem[] = [];
   const skippedRows: number[] = [];
@@ -184,9 +256,11 @@ export function ImportExcelModal({ className, onClose }: Props) {
 
   const validateFile = (file: File) => {
     const extension = file.name.split(".").pop()?.toLowerCase();
+    const isCsv = file.type === "text/csv" || extension === "csv";
+    const isXlsx = file.type === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" || extension === "xlsx";
 
-    if (!extension || !["csv", "xls", "xlsx"].includes(extension)) {
-      toast.error("Unsupported file type. Please upload a .csv, .xls, or .xlsx file.");
+    if (!isCsv && !isXlsx) {
+      toast.error("Unsupported file type. Please upload a .csv or .xlsx file.");
       return false;
     }
 
@@ -207,21 +281,19 @@ export function ImportExcelModal({ className, onClose }: Props) {
     setIsLoading(true);
 
     try {
-      const buffer = await file.arrayBuffer();
-      const workbook = XLSX.read(buffer, { type: "array" });
+      let rows: Record<string, unknown>[] = [];
+      const extension = file.name.split(".").pop()?.toLowerCase();
+      const isCsv = file.type === "text/csv" || extension === "csv";
 
-      if (!workbook.SheetNames.length) {
-        toast.error("The spreadsheet does not contain any sheets.");
-        return;
+      if (isCsv) {
+        const text = await file.text();
+        const parsedRows = parseCSV(text);
+        rows = sheetToJSON(parsedRows);
+      } else {
+        const parsedRows = await readSheet(file);
+        rows = sheetToJSON(parsedRows);
       }
 
-      const sheet = workbook.Sheets[workbook.SheetNames[0]];
-      if (!sheet) {
-        toast.error("Unable to read the first sheet in the spreadsheet.");
-        return;
-      }
-
-      const rows = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: null, raw: true });
       if (!rows.length) {
         toast.error("The selected file did not contain any importable rows.");
         return;
@@ -285,7 +357,7 @@ export function ImportExcelModal({ className, onClose }: Props) {
             ref={fileInputRef}
             className={styles.fileInput}
             type="file"
-            accept=".csv,.xls,.xlsx"
+            accept=".csv,.xlsx"
             onChange={handleFileChange}
           />
           <div
@@ -315,7 +387,7 @@ export function ImportExcelModal({ className, onClose }: Props) {
           >
             <IconUpload size={36} className={styles.dropIcon} />
             <div className={styles.dropText}>Drop your Excel or CSV file here</div>
-            <div className={styles.dropSub}>Supports .xlsx, .xls, .csv &mdash; max 10MB</div>
+            <div className={styles.dropSub}>Supports .xlsx, .csv &mdash; max 10MB</div>
             {selectedFile && <div className={styles.selectedFile}>{selectedFile.name}</div>}
           </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,10 @@
         "react-dom": "^19.2.7",
         "react-hook-form": "^7.77.0",
         "react-router": "^7.16.0",
+        "read-excel-file": "^9.2.0",
         "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "stripe": "^22.2.0",
-        "xlsx": "^0.18.5",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -3020,6 +3020,15 @@
         "node": ">= 20"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -3040,15 +3049,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/ai": {
@@ -3286,19 +3286,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -3328,15 +3315,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/compressible": {
@@ -3433,18 +3411,6 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -3883,6 +3849,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -3923,15 +3895,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -4045,6 +4008,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
@@ -4626,6 +4595,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
@@ -5129,6 +5104,20 @@
         }
       }
     },
+    "node_modules/read-excel-file": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.2.0.tgz",
+      "integrity": "sha512-jwSi8Q9oCmswrYMkuiKvJ6VdHbAXGQnANSOaHBNQZEm2XvaXx8d0t/V7oepgHqT9YWxlQE3HEuCtDZq8BZBmvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "fflate": "^0.8.3",
+        "unzipper-esm": "^0.13.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -5450,18 +5439,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -5567,6 +5544,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzipper-esm": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/unzipper-esm/-/unzipper-esm-0.13.2.tgz",
+      "integrity": "sha512-lt8GtgDYV8YcAFZNQuLyR2QvHI8C/TstpgsdjUn9ZxiWLJgn+e5uW6DsO3e/HUJVuWD57ZLLFMZ9xk26tePuHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -5821,45 +5811,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "react-dom": "^19.2.7",
     "react-hook-form": "^7.77.0",
     "react-router": "^7.16.0",
+    "read-excel-file": "^9.2.0",
     "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "stripe": "^22.2.0",
-    "xlsx": "^0.18.5",
     "zod": "^4.4.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## What changed

- Replaced the vulnerable `xlsx` dependency with `read-excel-file`.
- Updated `import-excel-modal.tsx` to use `readSheet` from `read-excel-file/browser`.
- Added CSV parsing while preserving the existing import workflow and validation logic.
- Unified parsing output so both `.xlsx` and `.csv` files map to the existing key-value record format used by the validation and submission logic.
- Updated file validation to drop support for the legacy `.xls` format. Only `.xlsx` and `.csv` files are now supported.
## Testing

-  Successfully imported `.xlsx` files.
-  Successfully imported `.csv` files.
-  Verified the existing validation and mapping logic.
-  Ran `npm run typecheck`.
-  Ran `npm run build`.

Fixes #88