### PR TITLE
feat: implement reusable rate limiting middleware

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -353,3 +353,17 @@ All contributors will be recognized in the project. We value every contribution 
   <br />
   <sub>Built with ❤️ by the FlipTrack community</sub>
 </div>
+
+---
+
+## Rate Limiting
+
+A reusable `rateLimit(request, limit, windowMs)` utility is available in `app/utils/rate-limit.server.ts`.
+
+Example:
+
+```ts
+await rateLimit(request, 5, 60_000);
+```
+
+This implementation currently uses an in-memory store. Because FlipTrack is deployed on Vercel, the in-memory cache is per serverless invocation and is not shared across instances. For production deployments requiring distributed rate limiting, consider using a shared backend such as Upstash Redis or Vercel KV.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -366,4 +366,4 @@ Example:
 await rateLimit(request, 5, 60_000);
 ```
 
-This implementation currently uses an in-memory store. Because FlipTrack is deployed on Vercel, the in-memory cache is per serverless invocation and is not shared across instances. For production deployments requiring distributed rate limiting, consider using a shared backend such as Upstash Redis or Vercel KV.
+This implementation uses a Prisma-backed PostgreSQL database for rate limiting. Expired records are periodically cleaned up using lightweight probabilistic cleanup to prevent unbounded table growth. For larger distributed deployments, a dedicated rate-limiting backend such as Upstash Redis may still be preferable.

--- a/app/routes/api.insights.ts
+++ b/app/routes/api.insights.ts
@@ -1,5 +1,6 @@
 import type { Route } from "./+types/api.insights";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
+import { rateLimit } from "~/utils/rate-limit.server";
 import { PrismaClient } from "@prisma/client";
 import { generateText } from "ai";
 import { createGroq } from "@ai-sdk/groq";
@@ -7,6 +8,8 @@ import { createGroq } from "@ai-sdk/groq";
 const prisma = new PrismaClient();
 
 export async function action({ request }: Route.ActionArgs) {
+  await rateLimit(request, 10, 60_000);
+
   const groq = createGroq({ apiKey: process.env.GROQ_API_KEY });
   const { supabase } = getSupabaseServerClient(request);
   const { data: { user } } = await supabase.auth.getUser();

--- a/app/routes/login-page.tsx
+++ b/app/routes/login-page.tsx
@@ -6,6 +6,7 @@ import { LoginForm } from "~/blocks/login-page/login-form";
 import { OAuthOptions } from "~/blocks/login-page/o-auth-options";
 import { MagicLinkOption } from "~/blocks/login-page/magic-link-option";
 import { SignupLink } from "~/blocks/login-page/signup-link";
+import { rateLimit } from "~/utils/rate-limit.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase, headers } = getSupabaseServerClient(request);
@@ -15,7 +16,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
+  await rateLimit(request, 5, 60_000);
+
   const { supabase, headers } = getSupabaseServerClient(request);
+
   const formData = await request.formData();
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;

--- a/app/routes/signup-page.tsx
+++ b/app/routes/signup-page.tsx
@@ -7,6 +7,7 @@ import { SignupForm } from "~/blocks/signup-page/signup-form";
 import { OAuthSignup } from "~/blocks/signup-page/o-auth-signup";
 import { LoginLink } from "~/blocks/signup-page/login-link";
 import { TermsAcceptance } from "~/blocks/signup-page/terms-acceptance";
+import { rateLimit } from "~/utils/rate-limit.server";
 
 const prisma = new PrismaClient();
 
@@ -18,7 +19,10 @@ export async function loader({ request }: Route.LoaderArgs) {
 }
 
 export async function action({ request }: Route.ActionArgs) {
+  await rateLimit(request, 5, 60_000);
+
   const { supabase, headers } = getSupabaseServerClient(request);
+
   const formData = await request.formData();
   const name = formData.get("name") as string;
   const email = formData.get("email") as string;

--- a/app/utils/rate-limit.server.ts
+++ b/app/utils/rate-limit.server.ts
@@ -1,0 +1,52 @@
+type RateLimitEntry = {
+  count: number;
+  resetAt: number;
+};
+
+const store = new Map<string, RateLimitEntry>();
+
+function getClientIp(request: Request): string {
+  const forwarded = request.headers
+    .get("x-forwarded-for")
+    ?.split(",")[0]
+    ?.trim();
+
+  return forwarded || request.headers.get("x-real-ip") || "unknown";
+}
+
+export async function rateLimit(
+  request: Request,
+  limit = 5,
+  windowMs = 60_000
+) {
+  const ip = getClientIp(request);
+  const now = Date.now();
+
+  const existing = store.get(ip);
+
+  if (!existing || existing.resetAt <= now) {
+    store.set(ip, {
+      count: 1,
+      resetAt: now + windowMs,
+    });
+    return;
+  }
+
+  existing.count++;
+
+  if (existing.count > limit) {
+    throw new Response(
+      JSON.stringify({
+        error: "Too many attempts. Please try again later.",
+      }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      }
+    );
+  }
+
+  store.set(ip, existing);
+}

--- a/app/utils/rate-limit.server.ts
+++ b/app/utils/rate-limit.server.ts
@@ -1,17 +1,14 @@
-type RateLimitEntry = {
-  count: number;
-  resetAt: number;
-};
+import { PrismaClient } from "@prisma/client";
 
-const store = new Map<string, RateLimitEntry>();
+const prisma = new PrismaClient();
 
-function getClientIp(request: Request): string {
-  const forwarded = request.headers
-    .get("x-forwarded-for")
-    ?.split(",")[0]
-    ?.trim();
-
-  return forwarded || request.headers.get("x-real-ip") || "unknown";
+export function getClientIp(request: Request): string {
+  return (
+    request.headers.get("x-vercel-forwarded-for") ||
+    request.headers.get("x-real-ip") ||
+    request.headers.get("x-forwarded-for")?.split(",")[0].trim() ||
+    "unknown_ip"
+  );
 }
 
 export async function rateLimit(
@@ -20,21 +17,35 @@ export async function rateLimit(
   windowMs = 60_000
 ) {
   const ip = getClientIp(request);
-  const now = Date.now();
+  const now = new Date();
 
-  const existing = store.get(ip);
+  const existing = await prisma.rateLimit.findUnique({
+    where: { ip },
+  });
 
-  if (!existing || existing.resetAt <= now) {
-    store.set(ip, {
-      count: 1,
-      resetAt: now + windowMs,
+  if (!existing) {
+    await prisma.rateLimit.create({
+      data: {
+        ip,
+        count: 1,
+        resetAt: new Date(now.getTime() + windowMs),
+      },
     });
     return;
   }
 
-  existing.count++;
+  if (existing.resetAt <= now) {
+    await prisma.rateLimit.update({
+      where: { ip },
+      data: {
+        count: 1,
+        resetAt: new Date(now.getTime() + windowMs),
+      },
+    });
+    return;
+  }
 
-  if (existing.count > limit) {
+  if (existing.count >= limit) {
     throw new Response(
       JSON.stringify({
         error: "Too many attempts. Please try again later.",
@@ -48,5 +59,12 @@ export async function rateLimit(
     );
   }
 
-  store.set(ip, existing);
+  await prisma.rateLimit.update({
+    where: { ip },
+    data: {
+      count: {
+        increment: 1,
+      },
+    },
+  });
 }

--- a/app/utils/rate-limit.server.ts
+++ b/app/utils/rate-limit.server.ts
@@ -19,33 +19,35 @@ export async function rateLimit(
   const ip = getClientIp(request);
   const now = new Date();
 
-  const existing = await prisma.rateLimit.findUnique({
+  const resetAt = new Date(now.getTime() + windowMs);
+
+  const result = await prisma.rateLimit.upsert({
     where: { ip },
+    create: {
+      ip,
+      count: 1,
+      resetAt,
+    },
+    update: {
+      count: {
+        increment: 1,
+      },
+    },
   });
 
-  if (!existing) {
-    await prisma.rateLimit.create({
-      data: {
-        ip,
-        count: 1,
-        resetAt: new Date(now.getTime() + windowMs),
-      },
-    });
-    return;
-  }
-
-  if (existing.resetAt <= now) {
+  if (result.resetAt <= now) {
     await prisma.rateLimit.update({
       where: { ip },
       data: {
         count: 1,
-        resetAt: new Date(now.getTime() + windowMs),
+        resetAt,
       },
     });
+
     return;
   }
 
-  if (existing.count >= limit) {
+  if (result.count > limit) {
     throw new Response(
       JSON.stringify({
         error: "Too many attempts. Please try again later.",
@@ -58,13 +60,4 @@ export async function rateLimit(
       }
     );
   }
-
-  await prisma.rateLimit.update({
-    where: { ip },
-    data: {
-      count: {
-        increment: 1,
-      },
-    },
-  });
 }

--- a/app/utils/rate-limit.server.ts
+++ b/app/utils/rate-limit.server.ts
@@ -19,6 +19,15 @@ export async function rateLimit(
   const ip = getClientIp(request);
   const now = new Date();
 
+  await prisma.rateLimit.deleteMany({
+    where: {
+      ip,
+      resetAt: {
+        lte: now,
+      },
+    },
+  });
+
   const resetAt = new Date(now.getTime() + windowMs);
 
   const result = await prisma.rateLimit.upsert({
@@ -26,7 +35,7 @@ export async function rateLimit(
     create: {
       ip,
       count: 1,
-      resetAt,
+      resetAt: new Date(now.getTime() + windowMs),
     },
     update: {
       count: {
@@ -35,17 +44,7 @@ export async function rateLimit(
     },
   });
 
-  if (result.resetAt <= now) {
-    await prisma.rateLimit.update({
-      where: { ip },
-      data: {
-        count: 1,
-        resetAt,
-      },
-    });
-
-    return;
-  }
+  
 
   if (result.count > limit) {
     throw new Response(
@@ -59,5 +58,16 @@ export async function rateLimit(
         },
       }
     );
+  }
+  if (Math.random() < 0.01) {
+    prisma.rateLimit
+      .deleteMany({
+        where: {
+          resetAt: {
+            lte: now,
+          },
+        },
+      })
+      .catch(console.error);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,7 +136,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -569,6 +568,31 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -576,6 +600,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -2423,7 +2448,6 @@
       "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.16.0.tgz",
       "integrity": "sha512-ZI26LhXH65HP6z89+VzTK4XXDibnJczCUNQOgZIabKXSx8bmSzwujHe0brFc/eBW8N+tFBn/OZ2UuqELi9MwBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0",
         "@react-router/express": "7.16.0",
@@ -2895,7 +2919,6 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.107.0.tgz",
       "integrity": "sha512-ChKzdlWVweMUUhr0U79JhMmgm1haS/C5JquaiCDr70JaGARRtjjoY9rkIheXWybXxTSNzRiQs3Sk8IAg1HS3ZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.107.0",
         "@supabase/functions-js": "2.107.0",
@@ -3013,7 +3036,6 @@
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3024,7 +3046,6 @@
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3035,7 +3056,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3301,7 +3321,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3910,7 +3929,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4955,7 +4973,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5081,7 +5098,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -5229,7 +5245,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5239,7 +5254,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5252,7 +5266,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
       "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5276,7 +5289,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5357,7 +5369,6 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
       "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -5472,8 +5483,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5865,7 +5875,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6047,7 +6056,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6209,7 +6217,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -136,6 +136,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -568,6 +569,7 @@
         "node": ">=6.9.0"
       }
     },
+
     "node_modules/@emnapi/core": {
       "version": "1.11.2",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
@@ -593,6 +595,7 @@
         "tslib": "^2.4.0"
       }
     },
+
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -2448,6 +2451,7 @@
       "resolved": "https://registry.npmjs.org/@react-router/serve/-/serve-7.16.0.tgz",
       "integrity": "sha512-ZI26LhXH65HP6z89+VzTK4XXDibnJczCUNQOgZIabKXSx8bmSzwujHe0brFc/eBW8N+tFBn/OZ2UuqELi9MwBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mjackson/node-fetch-server": "^0.2.0",
         "@react-router/express": "7.16.0",
@@ -2919,6 +2923,7 @@
       "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.107.0.tgz",
       "integrity": "sha512-ChKzdlWVweMUUhr0U79JhMmgm1haS/C5JquaiCDr70JaGARRtjjoY9rkIheXWybXxTSNzRiQs3Sk8IAg1HS3ZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@supabase/auth-js": "2.107.0",
         "@supabase/functions-js": "2.107.0",
@@ -3036,6 +3041,7 @@
       "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3046,6 +3052,7 @@
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3056,6 +3063,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3321,6 +3329,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3929,6 +3938,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
       "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -4973,6 +4983,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5098,6 +5109,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -5245,6 +5257,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5254,6 +5267,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5266,6 +5280,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.77.0.tgz",
       "integrity": "sha512-Sslh9YDYc0GDlWT/lxasnIduNo4v3yyvqRGvmGKUre5AFjDs/HV9/OafHGD8d+sB2yoL4UIL9L8X9i0WlZZebg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -5289,6 +5304,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.3.0.tgz",
       "integrity": "sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -5369,6 +5385,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
       "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -5483,7 +5500,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -5875,6 +5893,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6056,6 +6075,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -6217,6 +6237,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -569,33 +569,6 @@
         "node": ">=6.9.0"
       }
     },
-
-    "node_modules/@emnapi/core": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
-      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
-      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
@@ -603,7 +576,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }

--- a/prisma/migrations/20260708160733_add_rate_limit_model/migration.sql
+++ b/prisma/migrations/20260708160733_add_rate_limit_model/migration.sql
@@ -1,32 +1,4 @@
 -- CreateTable
-CREATE TABLE "Invite" (
-    "id" TEXT NOT NULL,
-    "teamId" TEXT NOT NULL,
-    "email" TEXT NOT NULL,
-    "role" TEXT NOT NULL,
-    "token" TEXT NOT NULL,
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "expiresAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "Invite_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "Integration" (
-    "id" TEXT NOT NULL,
-    "userId" TEXT NOT NULL,
-    "teamId" TEXT,
-    "platform" TEXT NOT NULL,
-    "accessToken" TEXT NOT NULL,
-    "refreshToken" TEXT,
-    "expiresAt" TIMESTAMP(3),
-    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updatedAt" TIMESTAMP(3) NOT NULL,
-
-    CONSTRAINT "Integration_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
 CREATE TABLE "RateLimit" (
     "ip" TEXT NOT NULL,
     "count" INTEGER NOT NULL DEFAULT 1,
@@ -36,30 +8,3 @@ CREATE TABLE "RateLimit" (
 
     CONSTRAINT "RateLimit_pkey" PRIMARY KEY ("ip")
 );
-
--- CreateIndex
-CREATE UNIQUE INDEX "Invite_token_key" ON "Invite"("token");
-
--- CreateIndex
-CREATE INDEX "Invite_teamId_idx" ON "Invite"("teamId");
-
--- CreateIndex
-CREATE INDEX "Invite_token_idx" ON "Invite"("token");
-
--- CreateIndex
-CREATE INDEX "Integration_userId_idx" ON "Integration"("userId");
-
--- CreateIndex
-CREATE INDEX "Integration_teamId_idx" ON "Integration"("teamId");
-
--- CreateIndex
-CREATE UNIQUE INDEX "Integration_userId_platform_key" ON "Integration"("userId", "platform");
-
--- AddForeignKey
-ALTER TABLE "Invite" ADD CONSTRAINT "Invite_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Integration" ADD CONSTRAINT "Integration_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "Integration" ADD CONSTRAINT "Integration_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/migrations/20260708160733_add_rate_limit_model/migration.sql
+++ b/prisma/migrations/20260708160733_add_rate_limit_model/migration.sql
@@ -1,0 +1,65 @@
+-- CreateTable
+CREATE TABLE "Invite" (
+    "id" TEXT NOT NULL,
+    "teamId" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "role" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Invite_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Integration" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "teamId" TEXT,
+    "platform" TEXT NOT NULL,
+    "accessToken" TEXT NOT NULL,
+    "refreshToken" TEXT,
+    "expiresAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Integration_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RateLimit" (
+    "ip" TEXT NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 1,
+    "resetAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RateLimit_pkey" PRIMARY KEY ("ip")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Invite_token_key" ON "Invite"("token");
+
+-- CreateIndex
+CREATE INDEX "Invite_teamId_idx" ON "Invite"("teamId");
+
+-- CreateIndex
+CREATE INDEX "Invite_token_idx" ON "Invite"("token");
+
+-- CreateIndex
+CREATE INDEX "Integration_userId_idx" ON "Integration"("userId");
+
+-- CreateIndex
+CREATE INDEX "Integration_teamId_idx" ON "Integration"("teamId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Integration_userId_platform_key" ON "Integration"("userId", "platform");
+
+-- AddForeignKey
+ALTER TABLE "Invite" ADD CONSTRAINT "Invite_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Integration" ADD CONSTRAINT "Integration_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Integration" ADD CONSTRAINT "Integration_teamId_fkey" FOREIGN KEY ("teamId") REFERENCES "Team"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,12 +127,12 @@ model User {
 }
 
 model Team {
-  id        String   @id @default(uuid())
-  name      String
-  ownerId   String   @unique
-  createdAt DateTime @default(now())
-  members   User[]
-  invites   Invite[]
+  id           String        @id @default(uuid())
+  name         String
+  ownerId      String        @unique
+  createdAt    DateTime      @default(now())
+  members      User[]
+  invites      Invite[]
   integrations Integration[]
 }
 
@@ -279,17 +279,25 @@ model Integration {
   id           String    @id @default(uuid())
   userId       String
   teamId       String?
-  platform     String    // e.g., "SHOPIFY", "EBAY"
-  accessToken  String    // Encrypted access token or API key
-  refreshToken String?   // Encrypted refresh token (optional)
+  platform     String // e.g., "SHOPIFY", "EBAY"
+  accessToken  String // Encrypted access token or API key
+  refreshToken String? // Encrypted refresh token (optional)
   expiresAt    DateTime? // Expiration date/time (optional)
   createdAt    DateTime  @default(now())
   updatedAt    DateTime  @updatedAt
 
-  user         User      @relation(fields: [userId], references: [id], onDelete: Cascade)
-  team         Team?     @relation(fields: [teamId], references: [id], onDelete: Cascade)
+  user User  @relation(fields: [userId], references: [id], onDelete: Cascade)
+  team Team? @relation(fields: [teamId], references: [id], onDelete: Cascade)
 
   @@unique([userId, platform])
   @@index([userId])
   @@index([teamId])
+}
+
+model RateLimit {
+  ip        String   @id
+  count     Int      @default(1)
+  resetAt   DateTime
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 }


### PR DESCRIPTION
## Description

This PR introduces a reusable backend rate-limiting utility to improve security against brute-force attacks and excessive API requests.

### Changes made
- Added a reusable `rateLimit(request, limit, windowMs)` utility in `app/utils/rate-limit.server.ts`
- Applied rate limiting to:
  - Login route (`login-page.tsx`)
  - Signup route (`signup-page.tsx`)
  - AI Insights API (`api.insights.ts`)
- Returns HTTP `429 Too Many Requests` with a clear error message when the request limit is exceeded
- Updated `CONTRIBUTING.md` with usage instructions and documented the limitations of the in-memory implementation for serverless environments.

### Notes
- The current repository does not contain a server-side `reset-password` action, so no changes were made there.
- The repository currently does not include a configured testing framework (see Issue #76), so unit tests were not added as part of this PR.

## Related Issues

Fixes #74

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots (if applicable)

N/A (Backend changes only)