### PR TITLE
fix(pricing): improve pricing toggle thumb visibility in light mode

### DIFF
--- a/app/blocks/pricing-page/pricing-cards.module.css
+++ b/app/blocks/pricing-page/pricing-cards.module.css
@@ -4,7 +4,7 @@
 .toggleLabel { font-size: 14px; color: var(--color-text-muted); }
 .toggleBtn { width: 44px; height: 24px; border-radius: var(--radius-full); background: var(--color-bg-elevated); border: 1px solid var(--color-border); position: relative; cursor: pointer; transition: background var(--transition-base); }
 .toggleBtn.active { background: var(--color-primary); }
-.thumb { width: 18px; height: 18px; background: white; border-radius: 50%; position: absolute; top: 2px; left: 2px; transition: left var(--transition-base); }
+.thumb { width: 18px; height: 18px; background: var(--color-text); border-radius: 50%; position: absolute; top: 2px; left: 2px; transition: left var(--transition-base); }
 .toggleBtn.active .thumb { left: 22px; background: var(--color-text-inverse); }
 .saveBadge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: var(--radius-full); background: var(--color-primary-glow); color: var(--color-primary); border: 1px solid rgba(0,255,136,0.2); }
 .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-6); align-items: start; }


### PR DESCRIPTION
## Summary

This PR fixes the pricing toggle thumb visibility issue in light mode.

### Changes

- Replaced the hardcoded `white` background of the pricing toggle thumb with the theme-aware CSS variable `var(--color-text)`.
- Preserved the existing appearance in dark mode.

### Testing

- ✅ Verified in Light Mode
- ✅ Verified in Dark Mode
- ✅ Toggle behavior remains unchanged

### Screenshot 
<img width="404" height="146" alt="image" src="https://github.com/user-attachments/assets/7302a4b6-644e-4e31-b6ce-958d542ce512" />

Closes #142