### PR TITLE
fix(stripe): handle subscription cancellation webhooks

### DIFF
--- a/app/routes/api.stripe.ts
+++ b/app/routes/api.stripe.ts
@@ -22,7 +22,11 @@ export async function action({ request }: Route.ActionArgs) {
     return new Response(`Webhook Error: ${err.message}`, { status: 400 });
   }
 
-  if (event.type === "customer.subscription.created" || event.type === "customer.subscription.updated") {
+  if (
+    event.type === "customer.subscription.created" ||
+    event.type === "customer.subscription.updated" ||
+    event.type === "customer.subscription.deleted"
+  ) {
     const subscription = event.data.object as Stripe.Subscription;
     const customerId = subscription.customer as string;
     
@@ -31,13 +35,19 @@ export async function action({ request }: Route.ActionArgs) {
     
     if (user) {
       let plan = "FREE";
-      const priceId = subscription.items.data[0].price.id;
-      if (priceId === process.env.STRIPE_PRO_PRICE_ID) plan = "PRO";
-      if (priceId === process.env.STRIPE_BUSINESS_PRICE_ID) plan = "BUSINESS";
+      let stripeSubId: string | null = subscription.id;
+      
+      if (event.type === "customer.subscription.deleted") {
+        stripeSubId = null;
+      } else if (subscription.status === "active" || subscription.status === "trialing") {
+        const priceId = subscription.items.data[0].price.id;
+        if (priceId === process.env.STRIPE_PRO_PRICE_ID) plan = "PRO";
+        if (priceId === process.env.STRIPE_BUSINESS_PRICE_ID) plan = "BUSINESS";
+      }
 
       await prisma.user.update({
         where: { id: user.id },
-        data: { plan: plan as any, stripeSubId: subscription.id },
+        data: { plan: plan as any, stripeSubId },
       });
     }
   }

--- a/app/routes/api.stripe.ts
+++ b/app/routes/api.stripe.ts
@@ -40,9 +40,11 @@ export async function action({ request }: Route.ActionArgs) {
       if (event.type === "customer.subscription.deleted") {
         stripeSubId = null;
       } else if (subscription.status === "active" || subscription.status === "trialing") {
-        const priceId = subscription.items.data[0].price.id;
-        if (priceId === process.env.STRIPE_PRO_PRICE_ID) plan = "PRO";
-        if (priceId === process.env.STRIPE_BUSINESS_PRICE_ID) plan = "BUSINESS";
+        const priceId = subscription.items?.data?.[0]?.price?.id;
+        if (priceId) {
+          if (priceId === process.env.STRIPE_PRO_PRICE_ID) plan = "PRO";
+          if (priceId === process.env.STRIPE_BUSINESS_PRICE_ID) plan = "BUSINESS";
+        }
       }
 
       await prisma.user.update({


### PR DESCRIPTION
## Description

This PR fixes a backend issue in the Stripe webhook handling where cancelled or inactive subscriptions could continue to retain premium access.

### Root Cause

The webhook handled `customer.subscription.created` and `customer.subscription.updated`, but:

- It granted `PRO`/`BUSINESS` access based only on the subscription's `price.id`.
- It did not verify that the subscription status was `active` or `trialing`.
- It did not handle the `customer.subscription.deleted` event, allowing cancelled subscriptions to retain premium access indefinitely.

### Changes Made

- Added support for the `customer.subscription.deleted` webhook.
- Downgrade users to the `FREE` plan when a subscription is deleted.
- Clear `stripeSubId` when a subscription is deleted.
- Updated the existing `customer.subscription.created` and `customer.subscription.updated` handlers to grant paid plans only when the subscription status is `active` or `trialing`.
- Refactored the webhook logic to reuse the common subscription parsing and user lookup, removing duplicate code while preserving existing behaviour.

## Related Issues

Closes #140 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Verification

- [x] Verified active/trialing subscriptions continue to receive the correct paid plan.
- [x] Verified cancelled, past_due, unpaid, and deleted subscriptions are downgraded appropriately.
- [x] `npm run typecheck` passes.
- [x] `npm run build` passes.

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
