### PR TITLE
fix: log Prisma connection status on startup

### DIFF
--- a/app/routes/ai-insights.tsx
+++ b/app/routes/ai-insights.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, Suspense } from "react";
 import { useLoaderData, useFetcher, Await } from "react-router";
 import type { Route } from "./+types/ai-insights";
-import { PrismaClient } from "@prisma/client";
+
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
 import styles from "./ai-insights.module.css";
 import { AiInsightsHeader } from "~/blocks/ai-insights/ai-insights-header";
@@ -10,6 +10,7 @@ import { BatchAnalysisStatus } from "~/blocks/ai-insights/batch-analysis-status"
 import { ItemAnalysisCards } from "~/blocks/ai-insights/item-analysis-cards";
 import { DetailedAnalysisModal } from "~/blocks/ai-insights/detailed-analysis-modal";
 import { IconLoader2 } from "@tabler/icons-react";
+import { prisma } from "~/utils/db.server";
 
 export interface AiInsightItem {
   id: string;
@@ -21,8 +22,6 @@ export interface AiInsightItem {
   targetPrice: number;
   purchasePrice: number;
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   try {

--- a/app/routes/analytics.tsx
+++ b/app/routes/analytics.tsx
@@ -1,11 +1,12 @@
 import { useLoaderData } from "react-router";
 import type { Route } from "./+types/analytics";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import styles from "./analytics.module.css";
 import { StaleInventoryCard } from "~/blocks/analytics/StaleInventoryCard";
 import { ProfitForecast } from "~/blocks/analytics/ProfitForecast";
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
@@ -13,7 +14,6 @@ export function headers(_: Route.HeadersArgs) {
   };
 }
 
-const prisma = new PrismaClient();
 const STALE_THRESHOLD_DAYS = 60;
 
 export async function loader({ request }: Route.LoaderArgs) {

--- a/app/routes/api.cron.prices.ts
+++ b/app/routes/api.cron.prices.ts
@@ -1,9 +1,8 @@
 import type { Route } from "./+types/api.cron.prices";
-import { PrismaClient } from "@prisma/client";
+
 import { runAllScrapers } from "~/services/scrapers";
 import { waitUntil } from "@vercel/functions";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   // Protect with cron secret

--- a/app/routes/api.export.tax.ts
+++ b/app/routes/api.export.tax.ts
@@ -1,9 +1,7 @@
 import type { Route } from "./+types/api.export.tax";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
 import { sanitizeCsvField } from "~/utils/csv.server";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/api.insights.ts
+++ b/app/routes/api.insights.ts
@@ -1,11 +1,10 @@
 import type { Route } from "./+types/api.insights";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
 import { rateLimit } from "~/utils/rate-limit.server";
-import { PrismaClient } from "@prisma/client";
+
 import { generateText } from "ai";
 import { createGroq } from "@ai-sdk/groq";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 export async function action({ request }: Route.ActionArgs) {
   await rateLimit(request, 10, 60_000);

--- a/app/routes/api.integrations.ts
+++ b/app/routes/api.integrations.ts
@@ -1,9 +1,8 @@
 import type { Route } from "./+types/api.integrations";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
-import { encrypt, decrypt } from "~/utils/encryption.server";
 
-const prisma = new PrismaClient();
+import { encrypt, decrypt } from "~/utils/encryption.server";
+import { prisma } from "~/utils/db.server";
 
 // Helper to decrypt integration credentials for returning in API response
 function decryptIntegration(integration: any) {

--- a/app/routes/api.inventory.search.ts
+++ b/app/routes/api.inventory.search.ts
@@ -1,8 +1,6 @@
 import type { Route } from "./+types/api.inventory.search";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/api.stripe.ts
+++ b/app/routes/api.stripe.ts
@@ -1,8 +1,8 @@
 import type { Route } from "./+types/api.stripe";
-import { PrismaClient } from "@prisma/client";
-import Stripe from "stripe";
 
-const prisma = new PrismaClient();
+import Stripe from "stripe";
+import { prisma } from "~/utils/db.server";
+
 const stripeKey = process.env.STRIPE_SECRET_KEY || "sk_test_placeholder";
 const stripe = new Stripe(stripeKey, { apiVersion: "2024-06-20" as any });
 

--- a/app/routes/api.webhooks.orders.ts
+++ b/app/routes/api.webhooks.orders.ts
@@ -24,12 +24,11 @@
  */
 
 import type { Route } from "./+types/api.webhooks.orders";
-import { PrismaClient } from "@prisma/client";
+
 import { z } from "zod";
 import crypto from "crypto";
 import { decrypt } from "~/utils/encryption.server";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 // ─── Constants mirroring Prisma enums ─────────────────────────────────────────
 

--- a/app/routes/app-layout.tsx
+++ b/app/routes/app-layout.tsx
@@ -1,11 +1,12 @@
 import { Outlet, redirect, useLoaderData } from "react-router";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import type { Route } from "./+types/app-layout";
 import { AppSidebar } from "~/blocks/__global/app-sidebar";
 import { BreadcrumbNavigation } from "~/blocks/__global/breadcrumb-navigation";
 import styles from "./app-layout.module.css";
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
@@ -16,8 +17,6 @@ export function headers(_: Route.HeadersArgs) {
 export function shouldRevalidate({ formMethod }: { formMethod: string }) {
   return formMethod !== "GET";
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase, headers } = getSupabaseServerClient(request);

--- a/app/routes/dashboard.tsx
+++ b/app/routes/dashboard.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { useLoaderData, Await } from "react-router";
 import type { Route } from "./+types/dashboard";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { PrismaClient, Prisma } from "@prisma/client";
+import { Prisma } from "@prisma/client";
 import styles from "./dashboard.module.css";
 import { DashboardHeader } from "~/blocks/dashboard/dashboard-header";
 import { StatsCardsRow } from "~/blocks/dashboard/stats-cards-row";
@@ -15,14 +15,13 @@ import { ExpenseCategoriesChart } from "~/blocks/dashboard/expense-categories-ch
 import { AIInsightsPanel } from "~/blocks/dashboard/ai-insights-panel";
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
 import { IconLoader2 } from "@tabler/icons-react";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
     "Cache-Control": CACHE_PRIVATE_NO_STORE,
   };
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/expenses-tracker.tsx
+++ b/app/routes/expenses-tracker.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useActionData, Await } from "react-router";
 import type { Route } from "./+types/expenses-tracker";
 import { toast } from "sonner";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import styles from "./expenses-tracker.module.css";
 import { ExpensesHeader } from "~/blocks/expenses-tracker/expenses-header";
 import { RecurringExpensesSection } from "~/blocks/expenses-tracker/recurring-expenses-section";
@@ -13,14 +13,13 @@ import { AddExpenseModal } from "~/blocks/expenses-tracker/add-expense-modal";
 import { Pagination } from "~/blocks/__global/pagination";
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
 import { IconLoader2 } from "@tabler/icons-react";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
     "Cache-Control": CACHE_PRIVATE_NO_STORE,
   };
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/income-statement.tsx
+++ b/app/routes/income-statement.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { useLoaderData, Await } from "react-router";
 import type { Route } from "./+types/income-statement";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import styles from "./income-statement.module.css";
 import { StatementHeader } from "~/blocks/income-statement/statement-header";
 import { SummaryCards } from "~/blocks/income-statement/summary-cards";
@@ -12,14 +12,13 @@ import { DetailedStatementTable } from "~/blocks/income-statement/detailed-state
 import { ExportOptions } from "~/blocks/income-statement/export-options";
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
 import { IconLoader2 } from "@tabler/icons-react";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
     "Cache-Control": CACHE_PRIVATE_NO_STORE,
   };
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/inventory-item-detail.tsx
+++ b/app/routes/inventory-item-detail.tsx
@@ -1,7 +1,7 @@
 import { useLoaderData } from "react-router";
 import type { Route } from "./+types/inventory-item-detail";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import styles from "./inventory-item-detail.module.css";
 import { ItemHeader } from "~/blocks/inventory-item-detail/item-header";
 import { ItemInfoCard } from "~/blocks/inventory-item-detail/item-info-card";
@@ -9,8 +9,7 @@ import { PriceHistoryChart } from "~/blocks/inventory-item-detail/price-history-
 import { MarketplaceComparison } from "~/blocks/inventory-item-detail/marketplace-comparison";
 import { SalesHistory } from "~/blocks/inventory-item-detail/sales-history";
 import { RelatedItems } from "~/blocks/inventory-item-detail/related-items";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 export async function loader({ request, params }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/inventory-management.tsx
+++ b/app/routes/inventory-management.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useActionData, useSearchParams, Await } from "react-rout
 import type { Route } from "./+types/inventory-management";
 import { toast } from "sonner";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { Prisma, PrismaClient, type Currency, type ItemCondition } from "@prisma/client";
+import { Prisma, type Currency, type ItemCondition } from "@prisma/client";
 import styles from "./inventory-management.module.css";
 import { IconLoader2 } from "@tabler/icons-react";
 import { InventoryHeader } from "~/blocks/inventory-management/inventory-header";
@@ -12,13 +12,12 @@ import { BulkActionsBar } from "~/blocks/inventory-management/bulk-actions-bar";
 import { AddItemModal } from "~/blocks/inventory-management/add-item-modal";
 import { ImportExcelModal } from "~/blocks/inventory-management/import-excel-modal";
 import { Pagination } from "~/blocks/__global/pagination";
+import { prisma } from "~/utils/db.server";
 export function headers(_: Route.HeadersArgs) {
   return {
     "Cache-Control": "private, no-store",
   };
 }
-
-const prisma = new PrismaClient();
 
 function parseSkippedRows(value: FormDataEntryValue | null) {
   if (typeof value !== "string") {

--- a/app/routes/market-prices.tsx
+++ b/app/routes/market-prices.tsx
@@ -2,7 +2,7 @@ import { Suspense } from "react";
 import { useLoaderData, Await } from "react-router";
 import type { Route } from "./+types/market-prices";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import styles from "./market-prices.module.css";
 import { MarketPricesHeader } from "~/blocks/market-prices/market-prices-header";
 import { PriceComparisonTable } from "~/blocks/market-prices/price-comparison-table";
@@ -10,14 +10,13 @@ import { PriceUpdateStatus } from "~/blocks/market-prices/price-update-status";
 import { PriceAlertsQuickAdd } from "~/blocks/market-prices/price-alerts-quick-add";
 import { CACHE_PRIVATE_SHARED_DATA } from "~/utils/cache-headers";
 import { IconLoader2 } from "@tabler/icons-react";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
     "Cache-Control": CACHE_PRIVATE_SHARED_DATA,
   };
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/price-alerts.tsx
+++ b/app/routes/price-alerts.tsx
@@ -1,7 +1,7 @@
 import { useState, Suspense } from "react";
 import type { Route } from "./+types/price-alerts";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { PrismaClient, Marketplace, AlertDirection, NotificationChannel } from "@prisma/client";
+import { Marketplace, AlertDirection, NotificationChannel } from "@prisma/client";
 import { useLoaderData, useSubmit, Await } from "react-router";
 import styles from "./price-alerts.module.css";
 import { AlertsHeader } from "~/blocks/price-alerts/alerts-header";
@@ -11,14 +11,13 @@ import { ActiveAlertsTable } from "~/blocks/price-alerts/active-alerts-table";
 import { AlertHistory } from "~/blocks/price-alerts/alert-history";
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
 import { IconLoader2 } from "@tabler/icons-react";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
     "Cache-Control": CACHE_PRIVATE_NO_STORE,
   };
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/sales-log.tsx
+++ b/app/routes/sales-log.tsx
@@ -3,7 +3,7 @@ import { useLoaderData, useActionData, useSearchParams, Await } from "react-rout
 import type { Route } from "./+types/sales-log";
 import { toast } from "sonner";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import styles from "./sales-log.module.css";
 import { SalesHeader } from "~/blocks/sales-log/sales-header";
 import { SalesSummaryCards } from "~/blocks/sales-log/sales-summary-cards";
@@ -12,8 +12,7 @@ import { LogSaleModal } from "~/blocks/sales-log/log-sale-modal";
 import type { SortField, SortDirection } from "~/blocks/sales-log/sales-table";
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
 import { IconLoader2 } from "@tabler/icons-react";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -2,7 +2,7 @@ import { useState, Suspense } from "react";
 import { useLoaderData, Await } from "react-router";
 import type { Route } from "./+types/settings";
 import { getSupabaseServerClient, getUserFromRequest } from "~/utils/supabase.server";
-import { PrismaClient, Currency, Theme } from "@prisma/client";
+import { Currency, Theme } from "@prisma/client";
 import { z } from "zod";
 import crypto from "crypto";
 import styles from "./settings.module.css";
@@ -15,14 +15,13 @@ import { TeamSection } from "~/blocks/settings/team-section";
 import { SecuritySection } from "~/blocks/settings/security-section";
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
 import { IconLoader2 } from "@tabler/icons-react";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
     "Cache-Control": CACHE_PRIVATE_NO_STORE,
   };
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/routes/signup-page.tsx
+++ b/app/routes/signup-page.tsx
@@ -1,15 +1,14 @@
 import { redirect } from "react-router";
 import type { Route } from "./+types/signup-page";
 import { getSupabaseServerClient, authSessionStorage } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import styles from "./signup-page.module.css";
 import { SignupForm } from "~/blocks/signup-page/signup-form";
 import { OAuthSignup } from "~/blocks/signup-page/o-auth-signup";
 import { LoginLink } from "~/blocks/signup-page/login-link";
 import { TermsAcceptance } from "~/blocks/signup-page/terms-acceptance";
 import { rateLimit } from "~/utils/rate-limit.server";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase, headers } = getSupabaseServerClient(request);

--- a/app/routes/tax-report-export.tsx
+++ b/app/routes/tax-report-export.tsx
@@ -1,7 +1,7 @@
 import { useLoaderData } from "react-router";
 import type { Route } from "./+types/tax-report-export";
 import { getSupabaseServerClient } from "~/utils/supabase.server";
-import { PrismaClient } from "@prisma/client";
+
 import { CACHE_PRIVATE_NO_STORE } from "~/utils/cache-headers";
 import styles from "./tax-report-export.module.css";
 import { TaxReportHeader } from "~/blocks/tax-report-export/tax-report-header";
@@ -9,14 +9,13 @@ import { ReportGenerator } from "~/blocks/tax-report-export/report-generator";
 import { ReportPreview } from "~/blocks/tax-report-export/report-preview";
 import { ExportOptions } from "~/blocks/tax-report-export/export-options";
 import { ReportHistory } from "~/blocks/tax-report-export/report-history";
+import { prisma } from "~/utils/db.server";
 
 export function headers(_: Route.HeadersArgs) {
   return {
     "Cache-Control": CACHE_PRIVATE_NO_STORE,
   };
 }
-
-const prisma = new PrismaClient();
 
 export async function loader({ request }: Route.LoaderArgs) {
   const { supabase } = getSupabaseServerClient(request);

--- a/app/services/scrapers/index.ts
+++ b/app/services/scrapers/index.ts
@@ -1,7 +1,5 @@
-import { PrismaClient, Marketplace } from "@prisma/client";
-
-const prisma = new PrismaClient();
-
+import { Marketplace } from "@prisma/client";
+import { prisma } from "~/utils/db.server";
 export interface PriceResult {
   marketplace: Marketplace;
   sku: string;

--- a/app/utils/db.server.ts
+++ b/app/utils/db.server.ts
@@ -1,0 +1,42 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+  prismaConnectionLogged?: boolean;
+};
+
+function createPrismaClient(): PrismaClient {
+  const client = new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["warn", "error"] : ["error"],
+  });
+
+  client
+    .$connect()
+    .then(() => {
+      if (!globalForPrisma.prismaConnectionLogged) {
+        globalForPrisma.prismaConnectionLogged = true;
+        console.log(
+          `✅ [prisma] Connected to the database successfully (${process.env.NODE_ENV ?? "development"} mode)`
+        );
+      }
+    })
+    .catch((error: unknown) => {
+      console.error("❌ [prisma] Failed to connect to the database on startup.");
+      console.error("   → Check that DATABASE_URL and DIRECT_URL are set in your .env file.");
+      console.error("   → Confirm your Supabase/Postgres instance is running and reachable.");
+      console.error('   → Make sure you have run "npx prisma generate" after any schema change.');
+      if (error instanceof Error) {
+        console.error(`   → ${error.message}`);
+      } else {
+        console.error(error);
+      }
+    });
+
+  return client;
+}
+
+export const prisma = globalForPrisma.prisma ?? createPrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}

--- a/app/utils/rate-limit.server.ts
+++ b/app/utils/rate-limit.server.ts
@@ -1,6 +1,4 @@
-import { PrismaClient } from "@prisma/client";
-
-const prisma = new PrismaClient();
+import { prisma } from "~/utils/db.server";
 
 export function getClientIp(request: Request): string {
   return (


### PR DESCRIPTION
## Description
During local development it wasn't obvious whether Prisma had connected successfully — there was no startup log confirming a healthy connection, and failures only surfaced later as confusing errors on the first database query.

The root cause was that `PrismaClient` was being instantiated separately in 23 different files across the codebase (nearly every route, plus a couple of services). With connections scattered like this, there was no single place to check or log connection status, and as a side effect every dev hot-reload spun up a new, un-closed connection pool.

This PR:
- Adds `app/utils/db.server.ts`, a single shared Prisma client that calls `$connect()` explicitly on startup and logs a clear ✅ success message, or a ❌ message with actionable next steps (check `DATABASE_URL`/`DIRECT_URL`, confirm the database is reachable, re-run `npx prisma generate`) if the connection fails
- Caches the client on `globalThis` in development so hot-reloads reuse the same connection instead of leaking new ones
- Updates all 23 files that previously ran `new PrismaClient()` to import the shared client from `~/utils/db.server` instead

Logging in only one of many scattered clients wouldn't reflect the app's real connection state, so consolidating to a single shared client was necessary to make the logging meaningful — this also resolves a related connection-pool leak in dev.

`prisma/seed.ts` and `scripts/create-demo-user.ts` are standalone one-off scripts and were intentionally left untouched.

## Related Issues
Fixes #<#83>

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
