### PR TITLE
fix(expenses): return success response after expense creation

### DIFF
--- a/app/routes/expenses-tracker.tsx
+++ b/app/routes/expenses-tracker.tsx
@@ -133,6 +133,8 @@ export async function action({ request }: Route.ActionArgs) {
         },
       });
     }
+
+    return { ok: true, intent: "create" };
   }
 
   if (intent === "update") {


### PR DESCRIPTION
## Description

This PR fixes the missing return statement in the `create` action of the Expenses Tracker.

Previously, the expense was successfully written to the database, but the action did not return a response. As a result, the frontend never received the expected success payload, preventing the success toast from appearing and the modal from closing.

This change returns the expected success response after the expense is created, allowing the existing client-side logic to complete the success flow correctly.

## Related Issues

Fixes #<ISSUE_NUMBER>

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Verification

- Added the missing success return in the `create` action.
- Verified that the change is limited to `app/routes/expenses-tracker.tsx`.
- `npm run typecheck` passes.
- Confirmed the fix aligns with the existing `toggle`, `update`, and `delete` action patterns.
- No unrelated files or refactors are included.

