### PR TITLE
fix: make pricing cards equal height

### DIFF
--- a/app/blocks/pricing-page/pricing-cards.module.css
+++ b/app/blocks/pricing-page/pricing-cards.module.css
@@ -7,8 +7,8 @@
 .thumb { width: 18px; height: 18px; background: var(--color-text); border-radius: 50%; position: absolute; top: 2px; left: 2px; transition: left var(--transition-base); }
 .toggleBtn.active .thumb { left: 22px; background: var(--color-text-inverse); }
 .saveBadge { font-size: 11px; font-weight: 600; padding: 2px 8px; border-radius: var(--radius-full); background: var(--color-primary-glow); color: var(--color-primary); border: 1px solid rgba(0,255,136,0.2); }
-.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-6); align-items: start; }
-.card { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-8); position: relative; transition: transform 250ms cubic-bezier(.2,.8,.2,1), box-shadow 250ms cubic-bezier(.2,.8,.2,1); animation: floatCard 6s ease-in-out infinite; will-change: transform, translate; }
+.grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-6); align-items: stretch; }
+.card { display: flex; flex-direction: column; height: 100%; background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--space-8); position: relative; transition: transform 250ms cubic-bezier(.2,.8,.2,1), box-shadow 250ms cubic-bezier(.2,.8,.2,1); animation: floatCard 6s ease-in-out infinite; will-change: transform, translate; }
 .card:nth-child(2) { animation-delay: -2s; }
 .card:nth-child(3) { animation-delay: -4s; }
 @keyframes floatCard { 0%, 100% { translate: 0 0; } 50% { translate: 0 -6px; } }
@@ -24,7 +24,7 @@
 .features { display: flex; flex-direction: column; gap: var(--space-3); margin-bottom: var(--space-8); }
 .feature { display: flex; align-items: flex-start; gap: var(--space-3); font-size: 13px; color: var(--color-text-muted); }
 .check { color: var(--color-primary); flex-shrink: 0; margin-top: 1px; }
-.btn { display: block; width: 100%; padding: 12px; border-radius: var(--radius-md); font-size: 14px; font-weight: 600; text-align: center; text-decoration: none; cursor: pointer; border: none; transition: background var(--transition-fast), box-shadow var(--transition-fast); }
+.btn { display: block; width: 100%; padding: 12px; border-radius: var(--radius-md); font-size: 14px; font-weight: 600; text-align: center; text-decoration: none; cursor: pointer; border: none; transition: background var(--transition-fast), box-shadow var(--transition-fast); margin-top: auto; }
 .btnOutline { background: transparent; border: 1px solid var(--color-border-strong); color: var(--color-text); }
 .btnOutline:hover { background: var(--color-bg-elevated); }
 .btnPrimary { background: var(--color-primary); color: var(--color-text-inverse); }


### PR DESCRIPTION
## Description

This PR fixes the inconsistent height of the pricing cards in the Pricing section.

### Changes made:
- Updated the pricing grid to use `align-items: stretch` for consistent card heights.
- Converted pricing cards into flex columns using `display: flex`, `flex-direction: column`, and `height: 100%`.
- Added `margin-top: auto` to the CTA button so it remains aligned at the bottom of every card regardless of the number of features.
- Improved the overall visual consistency and user experience of the pricing section without affecting responsiveness.

## Related Issues

Fixes #167 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Screenshots :

### Before
> Screenshot showing the pricing cards with different heights and misaligned CTA buttons.
<img width="959" height="420" alt="image" src="https://github.com/user-attachments/assets/5cc053a8-efc7-424d-b80d-f1cf786e2cfe" />


### After
> Screenshot showing all pricing cards with equal heights and bottom-aligned CTA buttons.
<img width="959" height="416" alt="image" src="https://github.com/user-attachments/assets/b98d561c-8894-46a6-99b6-bfbf31cce289" />
